### PR TITLE
Add `networkShare` property to validator entities

### DIFF
--- a/src/data/dto/validators.ts
+++ b/src/data/dto/validators.ts
@@ -30,6 +30,7 @@ export class ValidatorDto implements IValidator {
     this.minAmount = getMinAmount(apiValidator?.minimum_delegation_amount);
     this.maxAmount = getMaxAmount(apiValidator?.maximum_delegation_amount);
     this.reservedSlots = apiValidator?.reserved_slots ?? 0;
+    this.networkShare = apiValidator?.network_share ?? null;
   }
 
   id: string;
@@ -47,6 +48,7 @@ export class ValidatorDto implements IValidator {
   minAmount: string;
   maxAmount: string;
   reservedSlots: number;
+  networkShare: Maybe<string> = null;
 }
 
 export class ValidatorWithStateDto implements IValidator {
@@ -70,6 +72,7 @@ export class ValidatorWithStateDto implements IValidator {
     this.minAmount = getMinAmount(apiValidator?.bidder?.minimum_delegation_amount);
     this.maxAmount = getMaxAmount(apiValidator?.bidder?.maximum_delegation_amount);
     this.reservedSlots = apiValidator?.bidder?.reserved_slots ?? 0;
+    this.networkShare = apiValidator?.bidder?.network_share ?? null;
   }
 
   id: string;
@@ -87,6 +90,7 @@ export class ValidatorWithStateDto implements IValidator {
   minAmount: string;
   maxAmount: string;
   reservedSlots: number;
+  networkShare: Maybe<string>;
 }
 
 function getMinAmount(minAmount?: string) {

--- a/src/domain/validator/entities.ts
+++ b/src/domain/validator/entities.ts
@@ -20,4 +20,6 @@ export interface IValidator extends IEntity {
   readonly minAmount: string;
   readonly maxAmount: string;
   readonly reservedSlots: number;
+
+  readonly networkShare: Maybe<string>;
 }


### PR DESCRIPTION
### What does this PR do?

- Introduces a new `networkShare` property to `entities.ts` for improved data representation.
- Updates DTOs to ensure `networkShare` is mapped correctly from API responses.
- Sets a default value of `networkShare` to `null` when it is not available.

[WALLET-1275](https://make-software.atlassian.net/browse/WALLET-1275)

[WALLET-1275]: https://make-software.atlassian.net/browse/WALLET-1275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ