### PR TITLE
Add high-stake validator logic

### DIFF
--- a/src/data/dto/validators.ts
+++ b/src/data/dto/validators.ts
@@ -1,8 +1,10 @@
 import {
   formatAddress,
+  formatNetworkShare,
   formatTokenBalance,
   getDecimalTokenBalance,
   getUniqueId,
+  isHighStakeValidator,
 } from '../../utils';
 import { CSPR_DECIMALS, IValidator } from '../../domain';
 import { IApiValidator, IApiValidatorWithStake } from '../repositories';
@@ -31,6 +33,8 @@ export class ValidatorDto implements IValidator {
     this.maxAmount = getMaxAmount(apiValidator?.maximum_delegation_amount);
     this.reservedSlots = apiValidator?.reserved_slots ?? 0;
     this.networkShare = apiValidator?.network_share ?? null;
+    this.formattedNetworkShare = formatNetworkShare(this.networkShare);
+    this.isHighStakeValidator = isHighStakeValidator(this);
   }
 
   id: string;
@@ -49,6 +53,8 @@ export class ValidatorDto implements IValidator {
   maxAmount: string;
   reservedSlots: number;
   networkShare: Maybe<string> = null;
+  formattedNetworkShare: Maybe<string> = null;
+  isHighStakeValidator: boolean = false;
 }
 
 export class ValidatorWithStateDto implements IValidator {
@@ -73,6 +79,8 @@ export class ValidatorWithStateDto implements IValidator {
     this.maxAmount = getMaxAmount(apiValidator?.bidder?.maximum_delegation_amount);
     this.reservedSlots = apiValidator?.bidder?.reserved_slots ?? 0;
     this.networkShare = apiValidator?.bidder?.network_share ?? null;
+    this.formattedNetworkShare = formatNetworkShare(this.networkShare);
+    this.isHighStakeValidator = isHighStakeValidator(this);
   }
 
   id: string;
@@ -91,6 +99,8 @@ export class ValidatorWithStateDto implements IValidator {
   maxAmount: string;
   reservedSlots: number;
   networkShare: Maybe<string>;
+  formattedNetworkShare: Maybe<string>;
+  isHighStakeValidator: boolean;
 }
 
 function getMinAmount(minAmount?: string) {

--- a/src/domain/constants/casperNetwork.ts
+++ b/src/domain/constants/casperNetwork.ts
@@ -124,6 +124,7 @@ export const CSPR_BALANCE: ICsprBalance = {
 export const CSPR_TRANSFER_PAYMENT_AMOUNT = '0.1';
 export const CSPR_DELEGATION_PAYMENT_AMOUNT = '2.5';
 export const CSPR_DELEGATION_MIN_AMOUNT = '500';
+export const HIGH_STAKE_THRESHOLD = 5;
 export const CSPR_TRANSFER_MIN_AMOUNT = '2.5';
 export const CEP18_DEFAULT_TRANSFER_PAYMENT_AMOUNT = '1.5';
 export const NFT_DEFAULT_TRANSFER_PAYMENT_AMOUNT: Record<NftStandard, string> = {

--- a/src/domain/validator/entities.ts
+++ b/src/domain/validator/entities.ts
@@ -22,4 +22,6 @@ export interface IValidator extends IEntity {
   readonly reservedSlots: number;
 
   readonly networkShare: Maybe<string>;
+  readonly formattedNetworkShare: Maybe<string>;
+  readonly isHighStakeValidator: boolean;
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,7 +1,7 @@
 import Decimal from 'decimal.js';
 
 import { v4 } from 'uuid';
-import { FIAT_DECIMALS, TOKEN_DISPLAY_DECIMALS } from '../domain';
+import { FIAT_DECIMALS, HIGH_STAKE_THRESHOLD, IValidator, TOKEN_DISPLAY_DECIMALS } from '../domain';
 import { Maybe } from '../typings';
 
 export const noop = () => undefined;
@@ -170,3 +170,19 @@ export function getCep18FiatAmount(
     ? formatFiatBalance(new Decimal(decimalAmount).mul(rate ?? 0).toFixed())
     : new Decimal(decimalAmount).mul(rate ?? 0).toFixed();
 }
+
+export const isHighStakeValidator = (validator: Pick<IValidator, 'networkShare'>): boolean => {
+  const share = Number(validator.networkShare);
+  return !Number.isNaN(share) && share >= HIGH_STAKE_THRESHOLD;
+};
+
+export const formatNetworkShare = (networkShare: Maybe<string>): Maybe<string> => {
+  if (!networkShare) {
+    return null;
+  }
+  const num = Number(networkShare);
+  if (Number.isNaN(num)) {
+    return null;
+  }
+  return formatNumber(num, { precision: { max: 2, min: 2 } });
+};


### PR DESCRIPTION
### Description

This pull request introduces logic for identifying high-stake validators. Key changes include:

- `HIGH_STAKE_THRESHOLD` constant for defining high-stake validators.
- `isHighStakeValidator` utility for determining validators with significant network share.
- `formatNetworkShare` function for consistent formatting of network share data.
- Updated validator DTOs to include `formattedNetworkShare` and `isHighStakeValidator` properties.

These additions enhance the system's ability to handle and display high-stake validators effectively.