### PR TITLE
Support `contractPackageHash` for CsprTrade URLs

### DIFF
--- a/src/data/dto/common.test.ts
+++ b/src/data/dto/common.test.ts
@@ -92,7 +92,13 @@ describe('dto/common helpers', () => {
   });
 
   describe('getMarketDataProviderUrl', () => {
-    it('handles CsprTrade', () => {
+    it('handles CsprTrade with contract package hash', () => {
+      expect(getMarketDataProviderUrl('CsprTrade', null, null, 'cph-123')).toBe(
+        'https://cspr.trade/token-details/cph-123',
+      );
+    });
+
+    it('falls back to cspr.trade homepage without package hash', () => {
       expect(getMarketDataProviderUrl('CsprTrade')).toBe('https://cspr.trade/');
     });
 

--- a/src/data/dto/common.ts
+++ b/src/data/dto/common.ts
@@ -94,10 +94,13 @@ export function getMarketDataProviderUrl(
   marketDataProvider: Maybe<SupportedMarketDataProviders>,
   coingeckoId?: string | null,
   latestVersionContractHash?: string | null,
+  contractPackageHash?: string | null,
 ) {
   switch (marketDataProvider) {
     case 'CsprTrade':
-      return 'https://cspr.trade/'; // TODO link to token page
+      return contractPackageHash
+        ? `https://cspr.trade/token-details/${contractPackageHash}`
+        : 'https://cspr.trade/';
     case 'CoinGecko':
       return coingeckoId ? `https://www.coingecko.com/en/coins/${coingeckoId}` : null;
     case 'FriendlyMarket':

--- a/src/data/dto/deploys/Cep18DeployDto.ts
+++ b/src/data/dto/deploys/Cep18DeployDto.ts
@@ -69,6 +69,7 @@ export class Cep18DeployDto extends DeployDto implements ICep18Deploy {
       this.marketDataProvider,
       data?.contract_package?.coingecko_id,
       data?.contract_package?.latest_version_contract_hash,
+      data?.contract_package?.contract_package_hash,
     );
   }
 

--- a/src/data/dto/deploys/Cep18transferDeployDto.ts
+++ b/src/data/dto/deploys/Cep18transferDeployDto.ts
@@ -96,6 +96,7 @@ export class Cep18TransferDeployDto implements ICep18Deploy {
       this.marketDataProvider,
       data?.contract_package?.coingecko_id,
       data?.contract_package?.latest_version_contract_hash,
+      data?.contract_package?.contract_package_hash,
     );
   }
 

--- a/src/data/dto/tokens.ts
+++ b/src/data/dto/tokens.ts
@@ -46,6 +46,7 @@ export class TokenDto implements ITokenWithFiatBalance {
       this.marketDataProvider,
       apiToken?.coingecko_id,
       apiToken?.latest_version_contract_hash,
+      this.contractPackageHash,
     );
   }
 


### PR DESCRIPTION
## Description

Added support for `contractPackageHash` in CsprTrade URLs. Updated `getMarketDataProviderUrl` in common.ts to include `contractPackageHash` for token-specific URL generation. Enhanced DTOs to incorporate `contractPackageHash` where appropriate and added tests to verify behavior.

## Motivation

This change enables token-specific URL generation for CsprTrade by supporting `contractPackageHash`. This improves the flexibility of token operations.

## Related issues

<!-- Closes #..., Refs #... -->

## Notes for reviewers

Please check the added tests, especially the scenarios with and without `contractPackageHash`. Ensure no unintended side effects are introduced.

---

- [ ] Commits are signed off (DCO)
- [ ] Tests added or updated where applicable