### PR TITLE
fix(eip712): drop duplicated chain name row from domain rows (WALLET-1318)

### DIFF
--- a/src/data/dto/eip712/EIP712SignatureRequestDto.test.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.test.ts
@@ -116,4 +116,33 @@ describe('EIP712SignatureRequestDto', () => {
   it('carries the enrichment status', () => {
     expect(dto.enrichment).toEqual({ accounts: 'ok', contractPackage: 'ok' });
   });
+
+  it('excludes chain_name from domainRows (surfaced as chainName instead)', () => {
+    expect(dto.chainName).toBe('casper');
+    expect(dto.domainRows.find(r => r.label === 'Chain Name')).toBeUndefined();
+    expect(dto.domainRows.find(r => r.label === 'Package Hash')).toBeDefined();
+  });
+
+  it('handles a domain without chain_name', () => {
+    const noChainName = {
+      ...typedData,
+      domain: { contract_package_hash: PKG_HASH },
+      types: {
+        ...typedData.types,
+        EIP712Domain: [{ name: 'contract_package_hash', type: 'bytes32' }],
+      },
+    };
+    const d = new EIP712SignatureRequestDto({
+      typedData: noChainName,
+      signingPublicKeyHex: SIGNING_PK,
+      network: 'mainnet',
+      digest: '0xd',
+      accountInfoMap: {},
+      contractPackage: null,
+      enrichment: { accounts: 'ok', contractPackage: 'absent' },
+    });
+    expect(d.chainName).toBe('');
+    expect(d.domainRows.find(r => r.label === 'Chain Name')).toBeUndefined();
+    expect(d.domainRows.find(r => r.label === 'Package Hash')).toBeDefined();
+  });
 });

--- a/src/data/dto/eip712/EIP712SignatureRequestDto.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../domain';
 import { buildTypedDataDisplayModel } from '../../../utils';
 import { deriveKeyType, getAccountInfoFromMap } from '../common';
-import { resolveEip712AddressToAccountHash } from './common';
+import { EIP712_CHAIN_NAME_KEY, resolveEip712AddressToAccountHash } from './common';
 
 export interface IEIP712SignatureRequestDtoProps {
   typedData: IEIP712TypedData;
@@ -50,17 +50,21 @@ export class EIP712SignatureRequestDto implements IEIP712SignatureRequest {
     contractPackage,
     enrichment,
   }: IEIP712SignatureRequestDtoProps) {
-    const { domainRows, messageRows } = buildTypedDataDisplayModel(typedData, {
-      resolveAccountInfo: value => {
-        // address values may be a Casper public key or account hash — resolve to account hash first,
-        // then look up by it so the key matches what getAccountHashesFromTypedData fetched.
-        const accountHash = resolveEip712AddressToAccountHash(value);
-        return accountHash
-          ? (getAccountInfoFromMap(accountInfoMap, accountHash, 'accountHash') ?? null)
-          : null;
+    const { domainRows, messageRows } = buildTypedDataDisplayModel(
+      typedData,
+      {
+        resolveAccountInfo: value => {
+          // address values may be a Casper public key or account hash — resolve to account hash first,
+          // then look up by it so the key matches what getAccountHashesFromTypedData fetched.
+          const accountHash = resolveEip712AddressToAccountHash(value);
+          return accountHash
+            ? (getAccountInfoFromMap(accountInfoMap, accountHash, 'accountHash') ?? null)
+            : null;
+        },
+        contractPackage,
       },
-      contractPackage,
-    });
+      [EIP712_CHAIN_NAME_KEY],
+    );
 
     const signingKeyType = deriveKeyType(signingPublicKeyHex);
     // getAccountInfoFromMap yields runtime `undefined` for a missing key; normalize to null for Maybe<>.
@@ -70,7 +74,7 @@ export class EIP712SignatureRequestDto implements IEIP712SignatureRequest {
     this.signingKeyType = this.signingAccountInfo?.publicKey ? 'publicKey' : signingKeyType;
 
     this.network = network;
-    this.chainName = String(typedData.domain.chain_name ?? '');
+    this.chainName = String(typedData.domain[EIP712_CHAIN_NAME_KEY] ?? '');
     this.primaryType = typedData.primaryType;
     this.domainRows = domainRows;
     this.messageRows = messageRows;

--- a/src/data/dto/eip712/common.ts
+++ b/src/data/dto/eip712/common.ts
@@ -2,6 +2,14 @@ import { IEIP712Field, IEIP712TypedData } from '../../../domain';
 import { Maybe } from '../../../typings';
 import { getHashByType } from '../common';
 
+/**
+ * The EIP-712 domain key carrying the chain name. It is promoted to the dedicated
+ * `IEIP712SignatureRequest.chainName` field (and surfaced as a synthetic "Network" row by consumers),
+ * so it is excluded from the generic `domainRows` to avoid showing the same value twice. Keep the
+ * promote-and-exclude sites in sync via this single constant.
+ */
+export const EIP712_CHAIN_NAME_KEY = 'chain_name';
+
 /** Strip an optional `0x` prefix. */
 export const stripHexPrefix = (value: string): string =>
   value.startsWith('0x') ? value.slice(2) : value;

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -32,6 +32,7 @@ import {
   verifyTypedDataSignature,
 } from '../../../utils';
 import {
+  EIP712_CHAIN_NAME_KEY,
   EIP712SignatureRequestDto,
   getAccountHashesFromTypedData,
   stripHexPrefix,
@@ -100,7 +101,7 @@ export class EIP712Repository implements IEIP712Repository {
     const { digest, hashArtifacts } = this.computeDigest(typedData, options);
 
     const network =
-      getCasperNetworkByChainName(String(typedData.domain.chain_name ?? '')) ??
+      getCasperNetworkByChainName(String(typedData.domain[EIP712_CHAIN_NAME_KEY] ?? '')) ??
       networkParam ??
       null;
 

--- a/src/utils/eip712/displayModel.test.ts
+++ b/src/utils/eip712/displayModel.test.ts
@@ -128,4 +128,16 @@ describe('buildTypedDataDisplayModel', () => {
     );
     expect(model.messageRows.find(r => r.label === 'Value')!.accountInfo).toBeNull();
   });
+
+  it('keeps all domain keys when excludeDomainKeys is not provided', () => {
+    const model = buildTypedDataDisplayModel(typedData);
+    expect(model.domainRows.find(r => r.label === 'Chain Name')).toBeDefined();
+  });
+
+  it('omits domain keys listed in excludeDomainKeys', () => {
+    const model = buildTypedDataDisplayModel(typedData, {}, ['chain_name']);
+    expect(model.domainRows.find(r => r.label === 'Chain Name')).toBeUndefined();
+    expect(model.domainRows.find(r => r.label === 'Package Hash')).toBeDefined();
+    expect(model.messageRows.find(r => r.label === 'Owner')).toBeDefined();
+  });
 });

--- a/src/utils/eip712/displayModel.ts
+++ b/src/utils/eip712/displayModel.ts
@@ -91,12 +91,16 @@ function toRow(
 export function buildTypedDataDisplayModel(
   typedData: IEIP712TypedData,
   enrichment: IEIP712DisplayEnrichment = {},
+  excludeDomainKeys: readonly string[] = [],
 ): IEIP712DisplayModel {
   const { domain, types, primaryType, message } = typedData;
+  const exclude = new Set(excludeDomainKeys);
 
-  const domainRows = Object.entries(domain).map(([key, val]) =>
-    toRow(key, getTypeForField(key, types, 'EIP712Domain'), String(val), enrichment, 'domain'),
-  );
+  const domainRows = Object.entries(domain)
+    .filter(([key]) => !exclude.has(key))
+    .map(([key, val]) =>
+      toRow(key, getTypeForField(key, types, 'EIP712Domain'), String(val), enrichment, 'domain'),
+    );
 
   const messageFields = types[primaryType] ?? [];
   const messageRows = messageFields.map(field =>


### PR DESCRIPTION
## Problem

In the **Domain** section of the EIP-712 signing screen, the chain name was shown twice:

1. The synthetic **"Network"** row — built in the Wallet UI from `signatureRequest.chainName`.
2. A **"Chain Name"** row — coming from `signatureRequest.domainRows`.

Both rendered `typedData.domain.chain_name`.

## Root cause

`EIP712SignatureRequestDto` **promotes** `domain.chain_name` into a dedicated `chainName` field, but `buildTypedDataDisplayModel` also built `domainRows` via `Object.entries(domain)`, so `chain_name` **remained** there too (labelled "Chain Name").

## Changes

- Added an optional `excludeDomainKeys: readonly string[] = []` parameter to `buildTypedDataDisplayModel`, filtering domain keys out of `domainRows` (backwards-compatible — defaults to `[]`).
- `EIP712SignatureRequestDto` now passes `[EIP712_CHAIN_NAME_KEY]`, so `chain_name` is removed from `domainRows` while `chainName` stays for the synthetic "Network" row.
- Extracted a shared `EIP712_CHAIN_NAME_KEY` constant (`data/dto/eip712/common.ts`) to keep the promote-and-exclude sites in sync (DTO + repository).
- Tests: `chain_name` exclusion, other domain/message rows preserved, edge case for a domain without `chain_name`.

## Verification

- `yarn test` — EIP-712 suite: 69 passed.
- `yarn code:check` — types and lint clean (Prettier warnings only for unrelated files, not part of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)