### PR TITLE
refactor(eip712): align EIP-712 method names onto …TypedDataEIP712… convention

### DIFF
--- a/src/data/dto/eip712/EIP712SignatureRequestDto.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.ts
@@ -10,7 +10,7 @@ import {
   IEIP712SignatureRequest,
   IEIP712TypedData,
 } from '../../../domain';
-import { buildTypedDataDisplayModel } from '../../../utils';
+import { buildTypedDataEIP712DisplayModel } from '../../../utils';
 import { deriveKeyType, getAccountInfoFromMap } from '../common';
 import { resolveEip712AddressToAccountHash } from './common';
 
@@ -50,7 +50,7 @@ export class EIP712SignatureRequestDto implements IEIP712SignatureRequest {
     contractPackage,
     enrichment,
   }: IEIP712SignatureRequestDtoProps) {
-    const { domainRows, messageRows } = buildTypedDataDisplayModel(typedData, {
+    const { domainRows, messageRows } = buildTypedDataEIP712DisplayModel(typedData, {
       resolveAccountInfo: value => {
         // address values may be a Casper public key or account hash — resolve to account hash first,
         // then look up by it so the key matches what getAccountHashesFromTypedData fetched.

--- a/src/data/dto/eip712/EIP712SignatureRequestDto.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.ts
@@ -50,17 +50,21 @@ export class EIP712SignatureRequestDto implements IEIP712SignatureRequest {
     contractPackage,
     enrichment,
   }: IEIP712SignatureRequestDtoProps) {
-    const { domainRows, messageRows } = buildTypedDataEIP712DisplayModel(typedData, {
-      resolveAccountInfo: value => {
-        // address values may be a Casper public key or account hash — resolve to account hash first,
-        // then look up by it so the key matches what getAccountHashesFromTypedDataEIP712 fetched.
-        const accountHash = resolveEip712AddressToAccountHash(value);
-        return accountHash
-          ? (getAccountInfoFromMap(accountInfoMap, accountHash, 'accountHash') ?? null)
-          : null;
+    const { domainRows, messageRows } = buildTypedDataEIP712DisplayModel(
+      typedData,
+      {
+        resolveAccountInfo: value => {
+          // address values may be a Casper public key or account hash — resolve to account hash first,
+          // then look up by it so the key matches what getAccountHashesFromTypedDataEIP712 fetched.
+          const accountHash = resolveEip712AddressToAccountHash(value);
+          return accountHash
+            ? (getAccountInfoFromMap(accountInfoMap, accountHash, 'accountHash') ?? null)
+            : null;
+        },
+        contractPackage,
       },
-      contractPackage,
-    }, [EIP712_CHAIN_NAME_KEY]);
+      [EIP712_CHAIN_NAME_KEY],
+    );
 
     const signingKeyType = deriveKeyType(signingPublicKeyHex);
     // getAccountInfoFromMap yields runtime `undefined` for a missing key; normalize to null for Maybe<>.

--- a/src/data/dto/eip712/EIP712SignatureRequestDto.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.ts
@@ -53,7 +53,7 @@ export class EIP712SignatureRequestDto implements IEIP712SignatureRequest {
     const { domainRows, messageRows } = buildTypedDataEIP712DisplayModel(typedData, {
       resolveAccountInfo: value => {
         // address values may be a Casper public key or account hash — resolve to account hash first,
-        // then look up by it so the key matches what getAccountHashesFromTypedData fetched.
+        // then look up by it so the key matches what getAccountHashesFromTypedDataEIP712 fetched.
         const accountHash = resolveEip712AddressToAccountHash(value);
         return accountHash
           ? (getAccountInfoFromMap(accountInfoMap, accountHash, 'accountHash') ?? null)

--- a/src/data/dto/eip712/common.test.ts
+++ b/src/data/dto/eip712/common.test.ts
@@ -1,5 +1,5 @@
 import {
-  getAccountHashesFromTypedData,
+  getAccountHashesFromTypedDataEIP712,
   resolveEip712AddressToAccountHash,
   stripHexPrefix,
 } from './common';
@@ -26,9 +26,9 @@ const typedData = {
   message: { owner: OWNER, spender: SPENDER, value: '1000' },
 };
 
-describe('getAccountHashesFromTypedData', () => {
+describe('getAccountHashesFromTypedDataEIP712', () => {
   it('collects address-typed values plus the signing-key account hash, deduped', () => {
-    const hashes = getAccountHashesFromTypedData(typedData, SIGNING_PK);
+    const hashes = getAccountHashesFromTypedDataEIP712(typedData, SIGNING_PK);
 
     expect(hashes).toContain(OWNER);
     expect(hashes).toContain(SPENDER);
@@ -40,7 +40,7 @@ describe('getAccountHashesFromTypedData', () => {
   it('deduplicates a hash that appears in more than one address field', () => {
     // spender repeats owner's value → the resolved hash must appear exactly once
     const dupData = { ...typedData, message: { ...typedData.message, spender: OWNER } };
-    const hashes = getAccountHashesFromTypedData(dupData, SIGNING_PK);
+    const hashes = getAccountHashesFromTypedDataEIP712(dupData, SIGNING_PK);
     expect(hashes.filter(h => h === OWNER)).toHaveLength(1);
   });
 
@@ -50,7 +50,7 @@ describe('getAccountHashesFromTypedData', () => {
       types: { ...typedData.types, Permit: [{ name: 'value', type: 'uint256' }] },
       message: { value: '1' },
     };
-    const hashes = getAccountHashesFromTypedData(noAddr, SIGNING_PK);
+    const hashes = getAccountHashesFromTypedDataEIP712(noAddr, SIGNING_PK);
     expect(hashes).toEqual([getAccountHashFromPublicKey(SIGNING_PK)]);
   });
 
@@ -60,7 +60,7 @@ describe('getAccountHashesFromTypedData', () => {
       types: { ...typedData.types, Permit: [{ name: 'owner', type: 'address' }] },
       message: {}, // owner declared as address but absent
     };
-    const hashes = getAccountHashesFromTypedData(missingValue, SIGNING_PK);
+    const hashes = getAccountHashesFromTypedDataEIP712(missingValue, SIGNING_PK);
     expect(hashes).toEqual([getAccountHashFromPublicKey(SIGNING_PK)]);
     expect(hashes).not.toContain('undefined');
   });

--- a/src/data/dto/eip712/common.ts
+++ b/src/data/dto/eip712/common.ts
@@ -14,7 +14,7 @@ const ACCOUNT_HASH_REGEX = /^[\da-fA-F]{64}$/;
  * key (01/02-prefixed, 66/68 hex) or a bare account hash (64 hex), with an optional `0x` prefix.
  * Returns null when it cannot be resolved — including values that are neither (e.g. an ETH-style
  * 20-byte address or junk). This keeps a bad row from poisoning the whole batched `getAccountsInfo`
- * call: `getAccountHashesFromTypedData` drops nulls, so enrichment degrades per-row, not per-request.
+ * call: `getAccountHashesFromTypedDataEIP712` drops nulls, so enrichment degrades per-row, not per-request.
  */
 export const resolveEip712AddressToAccountHash = (rawValue: string): Maybe<string> => {
   const value = stripHexPrefix(String(rawValue));
@@ -32,7 +32,7 @@ export const resolveEip712AddressToAccountHash = (rawValue: string): Maybe<strin
  * domain and the primary-type message (resolved to account hashes), plus the signing key.
  * Deduplicated; null/empty results dropped.
  */
-export const getAccountHashesFromTypedData = (
+export const getAccountHashesFromTypedDataEIP712 = (
   typedData: IEIP712TypedData,
   signingPublicKeyHex: string,
 ): string[] => {

--- a/src/data/repositories/eip712/eip712.test.ts
+++ b/src/data/repositories/eip712/eip712.test.ts
@@ -55,9 +55,9 @@ describe('EIP712Repository', () => {
     expect(result.digest).toBe(EXPECTED_DIGEST);
   });
 
-  it('signTypedData computes then signs', () => {
+  it('signTypedDataEIP712 computes then signs', () => {
     const key = PrivateKey.fromHex('11'.repeat(32), KeyAlgorithm.SECP256K1);
-    const result = repo.signTypedData({ typedData: TYPED_DATA, privateKey: key });
+    const result = repo.signTypedDataEIP712({ typedData: TYPED_DATA, privateKey: key });
     expect(result.digest).toBe(EXPECTED_DIGEST);
   });
 

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -33,7 +33,7 @@ import {
 } from '../../../utils';
 import {
   EIP712SignatureRequestDto,
-  getAccountHashesFromTypedData,
+  getAccountHashesFromTypedDataEIP712,
   stripHexPrefix,
 } from '../../dto';
 
@@ -115,7 +115,7 @@ export class EIP712Repository implements IEIP712Repository {
 
     if (network) {
       // Pure-CPU; kept outside the try so a bug here surfaces instead of being mislabeled API flakiness.
-      const accountHashes = getAccountHashesFromTypedData(typedData, signingPublicKeyHex);
+      const accountHashes = getAccountHashesFromTypedDataEIP712(typedData, signingPublicKeyHex);
       try {
         accountInfoMap = await this._accountInfoRepository.getAccountsInfo({
           accountHashes,

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -24,7 +24,7 @@ import {
 import { Maybe } from '../../../typings';
 import {
   buildTypedDataDisplayModel,
-  computeTypedDataDigest,
+  computeTypedDataEIP712Digest,
   getCasperNetworkByChainName,
   recoverTypedDataSignerAddress,
   signTypedDataEIP712 as signTypedDataEIP712Util,
@@ -56,7 +56,7 @@ export class EIP712Repository implements IEIP712Repository {
 
   computeDigest(typedData: IEIP712TypedData, options?: IEIP712SignTypedDataOptions): IEIP712Digest {
     try {
-      return computeTypedDataDigest(typedData, options);
+      return computeTypedDataEIP712Digest(typedData, options);
     } catch (e) {
       throw isEIP712Error(e) ? e : new EIP712Error(e, 'computeDigest');
     }

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../domain';
 import { Maybe } from '../../../typings';
 import {
-  buildTypedDataDisplayModel,
+  buildTypedDataEIP712DisplayModel,
   computeTypedDataEIP712Digest,
   getCasperNetworkByChainName,
   recoverTypedDataSignerAddress,
@@ -63,7 +63,7 @@ export class EIP712Repository implements IEIP712Repository {
   }
 
   buildDisplayModel(typedData: IEIP712TypedData): IEIP712DisplayModel {
-    return buildTypedDataDisplayModel(typedData);
+    return buildTypedDataEIP712DisplayModel(typedData);
   }
 
   signDigest({ privateKey, digest }: IEIP712SignDigestParams): IEIP712SignResult {

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -26,10 +26,10 @@ import {
   buildTypedDataEIP712DisplayModel,
   computeTypedDataEIP712Digest,
   getCasperNetworkByChainName,
-  recoverTypedDataSignerAddress,
+  recoverTypedDataEIP712SignerAddress,
   signTypedDataEIP712 as signTypedDataEIP712Util,
   signTypedDataEIP712DigestWithKey,
-  verifyTypedDataSignature,
+  verifyTypedDataEIP712Signature,
 } from '../../../utils';
 import {
   EIP712SignatureRequestDto,
@@ -87,11 +87,11 @@ export class EIP712Repository implements IEIP712Repository {
   }
 
   recoverSigner(params: IEIP712RecoverSignerParams): string {
-    return recoverTypedDataSignerAddress(params);
+    return recoverTypedDataEIP712SignerAddress(params);
   }
 
   verifySignature(params: IEIP712VerifySignatureParams): boolean {
-    return verifyTypedDataSignature(params);
+    return verifyTypedDataEIP712Signature(params);
   }
 
   async prepareSignatureRequest({

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -27,8 +27,8 @@ import {
   computeTypedDataDigest,
   getCasperNetworkByChainName,
   recoverTypedDataSignerAddress,
-  signTypedData as signTypedDataUtil,
-  signTypedDataDigestWithKey,
+  signTypedDataEIP712 as signTypedDataEIP712Util,
+  signTypedDataEIP712DigestWithKey,
   verifyTypedDataSignature,
 } from '../../../utils';
 import {
@@ -42,7 +42,7 @@ import {
  * contract-package data over HTTP (best-effort — each lookup is isolated in its own try/catch, so a
  * flaky API never breaks the request). The other methods are synchronous pure-CPU work.
  *
- * `computeDigest`, `signDigest` and `signTypedData` wrap unexpected failures in {@link EIP712Error}.
+ * `computeDigest`, `signDigest` and `signTypedDataEIP712` wrap unexpected failures in {@link EIP712Error}.
  * `prepareSignatureRequest` surfaces digest/validation failures as {@link EIP712Error} (via
  * `computeDigest`) and swallows enrichment-lookup failures (best-effort). `recoverSigner` and
  * `verifySignature` surface raw library errors.
@@ -68,17 +68,21 @@ export class EIP712Repository implements IEIP712Repository {
 
   signDigest({ privateKey, digest }: IEIP712SignDigestParams): IEIP712SignResult {
     try {
-      return signTypedDataDigestWithKey(privateKey, digest);
+      return signTypedDataEIP712DigestWithKey(privateKey, digest);
     } catch (e) {
       throw isEIP712Error(e) ? e : new EIP712Error(e, 'signDigest');
     }
   }
 
-  signTypedData({ typedData, privateKey, options }: IEIP712SignTypedDataParams): IEIP712SignResult {
+  signTypedDataEIP712({
+    typedData,
+    privateKey,
+    options,
+  }: IEIP712SignTypedDataParams): IEIP712SignResult {
     try {
-      return signTypedDataUtil(typedData, privateKey, options);
+      return signTypedDataEIP712Util(typedData, privateKey, options);
     } catch (e) {
-      throw isEIP712Error(e) ? e : new EIP712Error(e, 'signTypedData');
+      throw isEIP712Error(e) ? e : new EIP712Error(e, 'signTypedDataEIP712');
     }
   }
 

--- a/src/domain/eip712/errors.test.ts
+++ b/src/domain/eip712/errors.test.ts
@@ -4,12 +4,12 @@ describe('EIP712Error', () => {
   it('carries type, errorCode and a public name', () => {
     const err = new EIP712Error(
       new Error('boom'),
-      'validateTypedData',
+      'validateTypedDataEIP712',
       SignTypedDataErrorCodes.INVALID_PARAMS,
     );
 
     expect(err.message).toBe('boom');
-    expect(err.type).toBe('validateTypedData');
+    expect(err.type).toBe('validateTypedDataEIP712');
     expect(err.errorCode).toBe('INVALID_PARAMS');
     expect(err.name).toBe('EIP712Error');
     expect(err.traceable).toBe(true);

--- a/src/domain/eip712/errors.ts
+++ b/src/domain/eip712/errors.ts
@@ -13,7 +13,7 @@ export type EIP712ErrorType =
   | 'resolveDomainTypes'
   | 'computeDigest'
   | 'signDigest'
-  | 'signTypedData'
+  | 'signTypedDataEIP712'
   | 'prepareSignatureRequest';
 
 export type IEIP712Error = IDomainError<EIP712ErrorType> & {

--- a/src/domain/eip712/errors.ts
+++ b/src/domain/eip712/errors.ts
@@ -9,7 +9,7 @@ export type SignTypedDataErrorCode =
   (typeof SignTypedDataErrorCodes)[keyof typeof SignTypedDataErrorCodes];
 
 export type EIP712ErrorType =
-  | 'validateTypedData'
+  | 'validateTypedDataEIP712'
   | 'resolveDomainTypes'
   | 'computeDigest'
   | 'signDigest'

--- a/src/domain/eip712/repository.ts
+++ b/src/domain/eip712/repository.ts
@@ -54,7 +54,7 @@ export interface IEIP712Repository {
   computeDigest(typedData: IEIP712TypedData, options?: IEIP712SignTypedDataOptions): IEIP712Digest;
   buildDisplayModel(typedData: IEIP712TypedData): IEIP712DisplayModel;
   signDigest(params: IEIP712SignDigestParams): IEIP712SignResult;
-  signTypedData(params: IEIP712SignTypedDataParams): IEIP712SignResult;
+  signTypedDataEIP712(params: IEIP712SignTypedDataParams): IEIP712SignResult;
   recoverSigner(params: IEIP712RecoverSignerParams): string;
   verifySignature(params: IEIP712VerifySignatureParams): boolean;
   prepareSignatureRequest(

--- a/src/utils/eip712/digest.test.ts
+++ b/src/utils/eip712/digest.test.ts
@@ -1,5 +1,5 @@
 import { PermitTypes, buildDomain } from '@casper-ecosystem/casper-eip-712';
-import { computeTypedDataDigest } from './digest';
+import { computeTypedDataEIP712Digest } from './digest';
 
 const DOMAIN = buildDomain('CasperSwap', '1', 'casper', '0x' + '01'.repeat(32));
 const MESSAGE = {
@@ -11,9 +11,9 @@ const MESSAGE = {
 };
 const TYPED_DATA = { domain: DOMAIN, types: PermitTypes, primaryType: 'Permit', message: MESSAGE };
 
-describe('computeTypedDataDigest', () => {
+describe('computeTypedDataEIP712Digest', () => {
   it('produces the stable EIP-712 digest', () => {
-    const { digest, resolvedDomainTypes, hashArtifacts } = computeTypedDataDigest(TYPED_DATA);
+    const { digest, resolvedDomainTypes, hashArtifacts } = computeTypedDataEIP712Digest(TYPED_DATA);
     expect(digest).toBe('0x545a8088d6365ada6ef282f4d5979c655cd428b4115cbf65f561bcd65767a98c');
     expect(resolvedDomainTypes.map(f => f.name)).toEqual([
       'name',
@@ -25,7 +25,9 @@ describe('computeTypedDataDigest', () => {
   });
 
   it('populates all six hash artifacts when requested', () => {
-    const { hashArtifacts } = computeTypedDataDigest(TYPED_DATA, { returnHashArtifacts: true });
+    const { hashArtifacts } = computeTypedDataEIP712Digest(TYPED_DATA, {
+      returnHashArtifacts: true,
+    });
     expect(hashArtifacts).toEqual({
       domainTypeString:
         'EIP712Domain(string name,string version,string chain_name,bytes32 contract_package_hash)',
@@ -40,6 +42,6 @@ describe('computeTypedDataDigest', () => {
 
   it('rejects unknown message fields only when asked', () => {
     const withExtra = { ...TYPED_DATA, message: { ...MESSAGE, extra: 1n } };
-    expect(() => computeTypedDataDigest(withExtra, { rejectUnknownFields: true })).toThrow();
+    expect(() => computeTypedDataEIP712Digest(withExtra, { rejectUnknownFields: true })).toThrow();
   });
 });

--- a/src/utils/eip712/digest.ts
+++ b/src/utils/eip712/digest.ts
@@ -16,7 +16,7 @@ import {
   validateTypedDataFieldTypes,
 } from './validation';
 
-export function computeTypedDataDigest(
+export function computeTypedDataEIP712Digest(
   typedData: IEIP712TypedData,
   options: IEIP712SignTypedDataOptions = {},
 ): IEIP712Digest {

--- a/src/utils/eip712/digest.ts
+++ b/src/utils/eip712/digest.ts
@@ -13,7 +13,7 @@ import {
   resolveDomainTypes,
   validateNoUnknownMessageFields,
   validatePrimaryType,
-  validateTypedDataFieldTypes,
+  validateTypedDataEIP712FieldTypes,
 } from './validation';
 
 export function computeTypedDataEIP712Digest(
@@ -25,7 +25,7 @@ export function computeTypedDataEIP712Digest(
 
   validatePrimaryType(types, primaryType);
   const resolvedDomainTypes = resolveDomainTypes(domain, types, domainTypes);
-  validateTypedDataFieldTypes(types);
+  validateTypedDataEIP712FieldTypes(types);
   if (rejectUnknownFields) {
     validateNoUnknownMessageFields(types, primaryType, message);
   }

--- a/src/utils/eip712/displayModel.test.ts
+++ b/src/utils/eip712/displayModel.test.ts
@@ -1,4 +1,8 @@
-import { buildTypedDataDisplayModel, getPresentationForType, keyToLabel } from './displayModel';
+import {
+  buildTypedDataEIP712DisplayModel,
+  getPresentationForType,
+  keyToLabel,
+} from './displayModel';
 
 const FULL_ADDR = 'a'.repeat(64); // 64 hex chars, no 0x prefix — like a Casper account hash
 const PKG_HASH = '0x' + '01'.repeat(32);
@@ -34,7 +38,7 @@ describe('keyToLabel', () => {
   });
 });
 
-describe('buildTypedDataDisplayModel', () => {
+describe('buildTypedDataEIP712DisplayModel', () => {
   const typedData = {
     domain: { chain_name: 'casper', contract_package_hash: PKG_HASH },
     types: {
@@ -53,7 +57,7 @@ describe('buildTypedDataDisplayModel', () => {
   };
 
   it('classifies presentation and leaves enrichment null on the sync path', () => {
-    const model = buildTypedDataDisplayModel(typedData);
+    const model = buildTypedDataEIP712DisplayModel(typedData);
 
     const pkg = model.domainRows.find(r => r.label === 'Package Hash')!;
     expect(pkg.presentation).toBe('hash');
@@ -88,7 +92,7 @@ describe('buildTypedDataDisplayModel', () => {
       message: { value: '1' },
     };
 
-    const pkg = buildTypedDataDisplayModel(undeclared).domainRows.find(
+    const pkg = buildTypedDataEIP712DisplayModel(undeclared).domainRows.find(
       r => r.label === 'Package Hash',
     )!;
     expect(pkg.type).toBe(''); // not declared in types.EIP712Domain
@@ -117,7 +121,7 @@ describe('buildTypedDataDisplayModel', () => {
       decimals: 9,
     };
 
-    const model = buildTypedDataDisplayModel(typedData, {
+    const model = buildTypedDataEIP712DisplayModel(typedData, {
       resolveAccountInfo: value => (value === FULL_ADDR ? accountInfo : null),
       contractPackage,
     });

--- a/src/utils/eip712/displayModel.test.ts
+++ b/src/utils/eip712/displayModel.test.ts
@@ -134,12 +134,12 @@ describe('buildTypedDataEIP712DisplayModel', () => {
   });
 
   it('keeps all domain keys when excludeDomainKeys is not provided', () => {
-    const model = buildTypedDataDisplayModel(typedData);
+    const model = buildTypedDataEIP712DisplayModel(typedData);
     expect(model.domainRows.find(r => r.label === 'Chain Name')).toBeDefined();
   });
 
   it('omits domain keys listed in excludeDomainKeys', () => {
-    const model = buildTypedDataDisplayModel(typedData, {}, ['chain_name']);
+    const model = buildTypedDataEIP712DisplayModel(typedData, {}, ['chain_name']);
     expect(model.domainRows.find(r => r.label === 'Chain Name')).toBeUndefined();
     expect(model.domainRows.find(r => r.label === 'Package Hash')).toBeDefined();
     expect(model.messageRows.find(r => r.label === 'Owner')).toBeDefined();

--- a/src/utils/eip712/displayModel.ts
+++ b/src/utils/eip712/displayModel.ts
@@ -88,7 +88,7 @@ function toRow(
   };
 }
 
-export function buildTypedDataDisplayModel(
+export function buildTypedDataEIP712DisplayModel(
   typedData: IEIP712TypedData,
   enrichment: IEIP712DisplayEnrichment = {},
 ): IEIP712DisplayModel {

--- a/src/utils/eip712/recover.test.ts
+++ b/src/utils/eip712/recover.test.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { PermitTypes, buildDomain, fromHex } from '@casper-ecosystem/casper-eip-712';
-import { computeTypedDataDigest } from './digest';
+import { computeTypedDataEIP712Digest } from './digest';
 import {
   CASPER_DOMAIN_TYPES,
   PermitTypes as ReexportedPermitTypes,
@@ -19,7 +19,7 @@ const MESSAGE = {
 const TYPED_DATA = { domain: DOMAIN, types: PermitTypes, primaryType: 'Permit', message: MESSAGE };
 
 function recoverableSig(): Uint8Array {
-  const { digest } = computeTypedDataDigest(TYPED_DATA);
+  const { digest } = computeTypedDataEIP712Digest(TYPED_DATA);
   const sig = secp256k1.sign(fromHex(digest), fromHex('11'.repeat(32)));
   const out = new Uint8Array(65);
   out.set(sig.toCompactRawBytes(), 0);
@@ -38,7 +38,7 @@ describe('recover/verify', () => {
 
   it('verifies a signature against the recovered address', () => {
     const sig = recoverableSig();
-    const { digest } = computeTypedDataDigest(TYPED_DATA);
+    const { digest } = computeTypedDataEIP712Digest(TYPED_DATA);
     const address = recoverTypedDataSignerAddress({ typedData: TYPED_DATA, signature: sig });
     expect(verifyTypedDataSignature({ digest, signature: sig, expectedAddress: address })).toBe(
       true,

--- a/src/utils/eip712/recover.test.ts
+++ b/src/utils/eip712/recover.test.ts
@@ -4,8 +4,8 @@ import { computeTypedDataEIP712Digest } from './digest';
 import {
   CASPER_DOMAIN_TYPES,
   PermitTypes as ReexportedPermitTypes,
-  recoverTypedDataSignerAddress,
-  verifyTypedDataSignature,
+  recoverTypedDataEIP712SignerAddress,
+  verifyTypedDataEIP712Signature,
 } from './recover';
 
 const DOMAIN = buildDomain('CasperSwap', '1', 'casper', '0x' + '01'.repeat(32));
@@ -29,7 +29,7 @@ function recoverableSig(): Uint8Array {
 
 describe('recover/verify', () => {
   it('recovers the expected Ethereum-style address', () => {
-    const address = recoverTypedDataSignerAddress({
+    const address = recoverTypedDataEIP712SignerAddress({
       typedData: TYPED_DATA,
       signature: recoverableSig(),
     });
@@ -39,10 +39,10 @@ describe('recover/verify', () => {
   it('verifies a signature against the recovered address', () => {
     const sig = recoverableSig();
     const { digest } = computeTypedDataEIP712Digest(TYPED_DATA);
-    const address = recoverTypedDataSignerAddress({ typedData: TYPED_DATA, signature: sig });
-    expect(verifyTypedDataSignature({ digest, signature: sig, expectedAddress: address })).toBe(
-      true,
-    );
+    const address = recoverTypedDataEIP712SignerAddress({ typedData: TYPED_DATA, signature: sig });
+    expect(
+      verifyTypedDataEIP712Signature({ digest, signature: sig, expectedAddress: address }),
+    ).toBe(true);
   });
 
   it('re-exports lib helpers for consumers', () => {

--- a/src/utils/eip712/recover.ts
+++ b/src/utils/eip712/recover.ts
@@ -15,11 +15,11 @@ import { resolveDomainTypes } from './validation';
 
 /**
  * NOTE: these wrappers are secp256k1 / Ethereum-style. `signature` must be the raw 65-byte
- * recoverable signature (r‖s‖v) and `recoverTypedDataSignerAddress` returns a 0x-prefixed 20-byte
+ * recoverable signature (r‖s‖v) and `recoverTypedDataEIP712SignerAddress` returns a 0x-prefixed 20-byte
  * Ethereum address. They do NOT accept the wallet's `02`-prefixed 64-byte wire format and do NOT
  * apply to ed25519 (use the native key's verifySignature for ed25519).
  */
-export function recoverTypedDataSignerAddress({
+export function recoverTypedDataEIP712SignerAddress({
   typedData,
   signature,
   options,
@@ -38,7 +38,7 @@ export function recoverTypedDataSignerAddress({
 }
 
 /** secp256k1 only; `signature` is the raw 65-byte recoverable sig (r‖s‖v) over the keccak256 digest. */
-export function verifyTypedDataSignature({
+export function verifyTypedDataEIP712Signature({
   digest,
   signature,
   expectedAddress,

--- a/src/utils/eip712/sign.test.ts
+++ b/src/utils/eip712/sign.test.ts
@@ -2,7 +2,7 @@ import { PrivateKey, KeyAlgorithm } from 'casper-js-sdk';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { PermitTypes, buildDomain, fromHex } from '@casper-ecosystem/casper-eip-712';
-import { computeTypedDataDigest } from './digest';
+import { computeTypedDataEIP712Digest } from './digest';
 import {
   signTypedDataEIP712,
   signTypedDataEIP712DigestWithKey,
@@ -65,7 +65,7 @@ describe('signTypedDataEIP712 (end-to-end)', () => {
       '0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9',
     );
 
-    const { digest } = computeTypedDataDigest(TYPED_DATA);
+    const { digest } = computeTypedDataEIP712Digest(TYPED_DATA);
     expect(result.digest).toBe(digest);
   });
 

--- a/src/utils/eip712/sign.test.ts
+++ b/src/utils/eip712/sign.test.ts
@@ -3,7 +3,11 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { PermitTypes, buildDomain, fromHex } from '@casper-ecosystem/casper-eip-712';
 import { computeTypedDataDigest } from './digest';
-import { signTypedData, signTypedDataDigestWithKey, signTypedDataWithRawKey } from './sign';
+import {
+  signTypedDataEIP712,
+  signTypedDataEIP712DigestWithKey,
+  signTypedDataEIP712WithRawKey,
+} from './sign';
 
 const DOMAIN = buildDomain('CasperSwap', '1', 'casper', '0x' + '01'.repeat(32));
 const MESSAGE = {
@@ -19,10 +23,10 @@ const EXPECTED_DIGEST = '0x545a8088d6365ada6ef282f4d5979c655cd428b4115cbf65f561b
 const EXPECTED_SECP_SIG =
   '02acebd9d168c39959011754c86c70ebb2dbf122c8f9f22e915c2300a1f256757876728402a1ba9cb5de947ac1d148a3552321741abc43f2e67fbd3a94a0e0a5cb';
 
-describe('signTypedDataDigestWithKey (secp256k1)', () => {
+describe('signTypedDataEIP712DigestWithKey (secp256k1)', () => {
   it('matches the reference secp256k1.sign(sha256(digest)) byte-for-byte (no double hash)', () => {
     const key = PrivateKey.fromHex(SCALAR_HEX, KeyAlgorithm.SECP256K1);
-    const result = signTypedDataDigestWithKey(key, EXPECTED_DIGEST);
+    const result = signTypedDataEIP712DigestWithKey(key, EXPECTED_DIGEST);
 
     const reference =
       '02' +
@@ -37,10 +41,10 @@ describe('signTypedDataDigestWithKey (secp256k1)', () => {
   });
 });
 
-describe('signTypedDataWithRawKey (ed25519)', () => {
+describe('signTypedDataEIP712WithRawKey (ed25519)', () => {
   it('produces a 01-prefixed signature that round-trips via the native key', () => {
     const scalar = fromHex('22'.repeat(32));
-    const result = signTypedDataWithRawKey(scalar, 'ed25519', EXPECTED_DIGEST);
+    const result = signTypedDataEIP712WithRawKey(scalar, 'ed25519', EXPECTED_DIGEST);
 
     expect(result.signature.startsWith('01')).toBe(true);
 
@@ -50,10 +54,10 @@ describe('signTypedDataWithRawKey (ed25519)', () => {
   });
 });
 
-describe('signTypedData (end-to-end)', () => {
+describe('signTypedDataEIP712 (end-to-end)', () => {
   it('computes digest then signs, attaching artifacts when requested', () => {
     const key = PrivateKey.fromHex(SCALAR_HEX, KeyAlgorithm.SECP256K1);
-    const result = signTypedData(TYPED_DATA, key, { returnHashArtifacts: true });
+    const result = signTypedDataEIP712(TYPED_DATA, key, { returnHashArtifacts: true });
 
     expect(result.digest).toBe(EXPECTED_DIGEST);
     expect(result.signature).toBe(EXPECTED_SECP_SIG);
@@ -67,7 +71,7 @@ describe('signTypedData (end-to-end)', () => {
 
   it('omits hashArtifacts when not requested', () => {
     const key = PrivateKey.fromHex(SCALAR_HEX, KeyAlgorithm.SECP256K1);
-    const result = signTypedData(TYPED_DATA, key);
+    const result = signTypedDataEIP712(TYPED_DATA, key);
     expect(result.hashArtifacts).toBeUndefined();
     expect(result.signature).toBe(EXPECTED_SECP_SIG);
   });

--- a/src/utils/eip712/sign.ts
+++ b/src/utils/eip712/sign.ts
@@ -22,7 +22,7 @@ import { computeTypedDataDigest } from './digest';
  * secp256k1 path applies a SHA-256 prehash; ed25519 receives and signs the digest bytes directly
  * with NO internal prehash.
  */
-export function signTypedDataDigestWithKey(
+export function signTypedDataEIP712DigestWithKey(
   privateKey: PrivateKey,
   digestHex: string,
 ): IEIP712SignResult {
@@ -34,22 +34,22 @@ export function signTypedDataDigestWithKey(
   };
 }
 
-export function signTypedDataWithRawKey(
+export function signTypedDataEIP712WithRawKey(
   scalarBytes: Uint8Array,
   scheme: EIP712SignatureScheme,
   digestHex: string,
 ): IEIP712SignResult {
   const algorithm = scheme === 'ed25519' ? KeyAlgorithm.ED25519 : KeyAlgorithm.SECP256K1;
   const privateKey = PrivateKey.fromHex(convertBytesToHex(scalarBytes), algorithm);
-  return signTypedDataDigestWithKey(privateKey, digestHex);
+  return signTypedDataEIP712DigestWithKey(privateKey, digestHex);
 }
 
-export function signTypedData(
+export function signTypedDataEIP712(
   typedData: IEIP712TypedData,
   privateKey: PrivateKey,
   options: IEIP712SignTypedDataOptions = {},
 ): IEIP712SignResult {
   const { digest, hashArtifacts } = computeTypedDataDigest(typedData, options);
-  const result = signTypedDataDigestWithKey(privateKey, digest);
+  const result = signTypedDataEIP712DigestWithKey(privateKey, digest);
   return hashArtifacts ? { ...result, hashArtifacts } : result;
 }

--- a/src/utils/eip712/sign.ts
+++ b/src/utils/eip712/sign.ts
@@ -7,7 +7,7 @@ import {
   IEIP712TypedData,
 } from '../../domain';
 import { convertBytesToHex } from '../crypto';
-import { computeTypedDataDigest } from './digest';
+import { computeTypedDataEIP712Digest } from './digest';
 
 /**
  * Sign an EIP-712 digest with a casper-js-sdk PrivateKey.
@@ -49,7 +49,7 @@ export function signTypedDataEIP712(
   privateKey: PrivateKey,
   options: IEIP712SignTypedDataOptions = {},
 ): IEIP712SignResult {
-  const { digest, hashArtifacts } = computeTypedDataDigest(typedData, options);
+  const { digest, hashArtifacts } = computeTypedDataEIP712Digest(typedData, options);
   const result = signTypedDataEIP712DigestWithKey(privateKey, digest);
   return hashArtifacts ? { ...result, hashArtifacts } : result;
 }

--- a/src/utils/eip712/validation.test.ts
+++ b/src/utils/eip712/validation.test.ts
@@ -5,7 +5,7 @@ import {
   resolveDomainTypes,
   validateNoUnknownMessageFields,
   validatePrimaryType,
-  validateTypedDataFieldTypes,
+  validateTypedDataEIP712FieldTypes,
 } from './validation';
 
 const DOMAIN = buildDomain('CasperSwap', '1', 'casper', '0x' + '01'.repeat(32));
@@ -63,16 +63,16 @@ describe('resolveDomainTypes (4-step priority)', () => {
   });
 });
 
-describe('validateTypedDataFieldTypes', () => {
+describe('validateTypedDataEIP712FieldTypes', () => {
   it('rejects array types', () => {
-    expect(() => validateTypedDataFieldTypes({ T: [{ name: 'a', type: 'uint256[]' }] })).toThrow(
-      EIP712Error,
-    );
+    expect(() =>
+      validateTypedDataEIP712FieldTypes({ T: [{ name: 'a', type: 'uint256[]' }] }),
+    ).toThrow(EIP712Error);
   });
 
   it('allows bytes32', () => {
     expect(() =>
-      validateTypedDataFieldTypes({ T: [{ name: 'a', type: 'bytes32' }] }),
+      validateTypedDataEIP712FieldTypes({ T: [{ name: 'a', type: 'bytes32' }] }),
     ).not.toThrow();
   });
 
@@ -80,7 +80,7 @@ describe('validateTypedDataFieldTypes', () => {
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 31 }), n => {
         try {
-          validateTypedDataFieldTypes({ T: [{ name: 'a', type: `bytes${n}` }] });
+          validateTypedDataEIP712FieldTypes({ T: [{ name: 'a', type: `bytes${n}` }] });
           return false;
         } catch (e) {
           return (e as EIP712Error).errorCode === SignTypedDataErrorCodes.UNSUPPORTED_TYPE;

--- a/src/utils/eip712/validation.ts
+++ b/src/utils/eip712/validation.ts
@@ -8,7 +8,7 @@ export function validatePrimaryType(types: IEIP712Types, primaryType: string): v
   if (!types[primaryType]) {
     throw new EIP712Error(
       new Error(`Primary type "${primaryType}" not found in type definitions`),
-      'validateTypedData',
+      'validateTypedDataEIP712',
       SignTypedDataErrorCodes.INVALID_PARAMS,
     );
   }
@@ -42,13 +42,13 @@ export function resolveDomainTypes(
   return CASPER_DOMAIN_TYPES.filter(f => domain[f.name] != null);
 }
 
-export function validateTypedDataFieldTypes(types: IEIP712Types): void {
+export function validateTypedDataEIP712FieldTypes(types: IEIP712Types): void {
   for (const [typeName, fields] of Object.entries(types)) {
     for (const field of fields) {
       if (ARRAY_PATTERN.test(field.type)) {
         throw new EIP712Error(
           new Error(`Array types are not supported: "${field.type}" in ${typeName}.${field.name}`),
-          'validateTypedData',
+          'validateTypedDataEIP712',
           SignTypedDataErrorCodes.UNSUPPORTED_TYPE,
         );
       }
@@ -57,7 +57,7 @@ export function validateTypedDataFieldTypes(types: IEIP712Types): void {
           new Error(
             `bytes1..bytes31 types are not supported: "${field.type}" in ${typeName}.${field.name}`,
           ),
-          'validateTypedData',
+          'validateTypedDataEIP712',
           SignTypedDataErrorCodes.UNSUPPORTED_TYPE,
         );
       }
@@ -75,7 +75,7 @@ export function validateNoUnknownMessageFields(
     if (!knownFields.has(key)) {
       throw new EIP712Error(
         new Error(`Unknown field "${key}" in message not defined in type "${primaryType}"`),
-        'validateTypedData',
+        'validateTypedDataEIP712',
         SignTypedDataErrorCodes.INVALID_PARAMS,
       );
     }


### PR DESCRIPTION
## Summary

Pure, behavior-preserving rename that aligns all EIP-712 **method/function** names onto a single convention: the `EIP712` token is inserted immediately after the `TypedData` segment of each name (e.g. `signTypedData` → `signTypedDataEIP712`). This matches CSPR.click's `SignTypedDataEIP712` / the `sign-typed-data-eip712` feature string and removes the previous split where **types** were `EIP712`-prefixed but **methods** used a bare `TypedData` token.

TypeScript **type** names already carried an `EIP712` prefix and were intentionally left unchanged — `TypedData` as a *noun* (the EIP-712 payload object) is legitimate domain terminology.

## Rename map

| Old | New |
|---|---|
| `signTypedData` (util fn + repo method + interface) | `signTypedDataEIP712` |
| `signTypedDataDigestWithKey` | `signTypedDataEIP712DigestWithKey` |
| `signTypedDataWithRawKey` | `signTypedDataEIP712WithRawKey` |
| import alias `signTypedDataUtil` | `signTypedDataEIP712Util` |
| error tag `'signTypedData'` | `'signTypedDataEIP712'` |
| `computeTypedDataDigest` | `computeTypedDataEIP712Digest` |
| `buildTypedDataDisplayModel` | `buildTypedDataEIP712DisplayModel` |
| `validateTypedDataFieldTypes` | `validateTypedDataEIP712FieldTypes` |
| error tag `'validateTypedData'` | `'validateTypedDataEIP712'` |
| `recoverTypedDataSignerAddress` | `recoverTypedDataEIP712SignerAddress` |
| `verifyTypedDataSignature` | `verifyTypedDataEIP712Signature` |
| `getAccountHashesFromTypedData` | `getAccountHashesFromTypedDataEIP712` |

## Left unchanged (by design)

- All `IEIP712*` / `EIP712*` type names (incl. `IEIP712TypedData`, `IEIP712SignTypedDataParams`, `IEIP712SignTypedDataOptions`).
- `SignTypedDataErrorCodes` / `SignTypedDataErrorCode`.
- `hashTypedData` (external `@casper-ecosystem/casper-eip-712` import).
- Token-less repo methods (`computeDigest`, `buildDisplayModel`, `signDigest`, `recoverSigner`, `verifySignature`, `prepareSignatureRequest`) and util fns (`validatePrimaryType`, `resolveDomainTypes`, `validateNoUnknownMessageFields`, `getPresentationForType`, `keyToLabel`).

## Notes

- No production consumers yet — done as a clean rename with no deprecated aliases.
- Each rename is its own commit for easy review.
- Follow-up: the same convention will be propagated to `casper-wallet-playground`, `casper-wallet`, and `casper-wallet-mobile` in separate PRs.

## Testing

- `yarn tsc --skipLibCheck --noEmit` — clean
- `yarn test` — 44 suites / 448 tests pass
- Stale-reference sweep across `src/` — zero remaining old names