### PR TITLE
feat(eip712): decode address as Casper Keys, date presentation & CAIP-2

### DIFF
--- a/src/data/dto/eip712/EIP712SignatureRequestDto.test.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.test.ts
@@ -1,11 +1,11 @@
 import { EIP712SignatureRequestDto } from './EIP712SignatureRequestDto';
 
 const OWNER = 'a'.repeat(64);
-const PKG_HASH = '0x' + '01'.repeat(32);
+const PKG_HASH = '01'.repeat(32); // 64 hex chars, no 0x prefix (clean hash used in map key)
 const SIGNING_PK = '0106956df3aba7115e28271d053205ec7f33cab259f8e2da2f38150f0ece65a2a8';
 
 const typedData = {
-  domain: { chain_name: 'casper', contract_package_hash: PKG_HASH },
+  domain: { chain_name: 'casper', contract_package_hash: '0x' + PKG_HASH },
   types: {
     EIP712Domain: [
       { name: 'chain_name', type: 'string' },
@@ -17,7 +17,8 @@ const typedData = {
     ],
   },
   primaryType: 'Permit',
-  message: { owner: OWNER, value: '1000' },
+  // owner is an account-tagged address (0x00 prefix + 64-hex hash)
+  message: { owner: '00' + OWNER, value: '1000' },
 };
 
 const ownerAccountInfo = {
@@ -47,12 +48,15 @@ describe('EIP712SignatureRequestDto', () => {
     network: 'mainnet',
     digest: '0xdigest',
     accountInfoMap: { [OWNER]: ownerAccountInfo },
-    contractPackage,
+    contractPackageMap: { [PKG_HASH]: contractPackage },
     enrichment: { accounts: 'ok', contractPackage: 'ok' },
   });
 
   it('enriches address rows with account info', () => {
-    expect(dto.messageRows.find(r => r.label === 'Owner')!.accountInfo).toEqual(ownerAccountInfo);
+    const ownerRow = dto.messageRows.find(r => r.label === 'Owner')!;
+    expect(ownerRow.accountInfo).toEqual(ownerAccountInfo);
+    // value should be the clean hash (tag stripped)
+    expect(ownerRow.value).toBe(OWNER);
   });
 
   it('enriches the contract_package_hash row with the contract package', () => {
@@ -67,7 +71,6 @@ describe('EIP712SignatureRequestDto', () => {
     expect(dto.primaryType).toBe('Permit');
     expect(dto.digest).toBe('0xdigest');
     expect(dto.id).toBe('0xdigest');
-    expect(JSON.parse(dto.rawJson)).toEqual(typedData);
     expect(dto.hashArtifacts).toBeUndefined();
   });
 
@@ -87,7 +90,7 @@ describe('EIP712SignatureRequestDto', () => {
       digest: '0xdigest',
       hashArtifacts: artifacts,
       accountInfoMap: {},
-      contractPackage: null,
+      contractPackageMap: {},
       enrichment: { accounts: 'ok', contractPackage: 'absent' },
     });
     expect(withArtifacts.hashArtifacts).toEqual(artifacts);
@@ -100,14 +103,14 @@ describe('EIP712SignatureRequestDto', () => {
   });
 
   it('serializes bigint message values in rawJson', () => {
-    const bigintData = { ...typedData, message: { owner: OWNER, value: 1000n } };
+    const bigintData = { ...typedData, message: { owner: '00' + OWNER, value: 1000n } };
     const d = new EIP712SignatureRequestDto({
       typedData: bigintData,
       signingPublicKeyHex: SIGNING_PK,
       network: 'mainnet',
       digest: '0xd',
       accountInfoMap: {},
-      contractPackage: null,
+      contractPackageMap: {},
       enrichment: { accounts: 'ok', contractPackage: 'absent' },
     });
     expect(JSON.parse(d.rawJson).message.value).toBe('1000');
@@ -126,7 +129,7 @@ describe('EIP712SignatureRequestDto', () => {
   it('handles a domain without chain_name', () => {
     const noChainName = {
       ...typedData,
-      domain: { contract_package_hash: PKG_HASH },
+      domain: { contract_package_hash: '0x' + PKG_HASH },
       types: {
         ...typedData.types,
         EIP712Domain: [{ name: 'contract_package_hash', type: 'bytes32' }],
@@ -138,11 +141,24 @@ describe('EIP712SignatureRequestDto', () => {
       network: 'mainnet',
       digest: '0xd',
       accountInfoMap: {},
-      contractPackage: null,
+      contractPackageMap: {},
       enrichment: { accounts: 'ok', contractPackage: 'absent' },
     });
     expect(d.chainName).toBe('');
     expect(d.domainRows.find(r => r.label === 'Chain Name')).toBeUndefined();
     expect(d.domainRows.find(r => r.label === 'Package Hash')).toBeDefined();
+  });
+
+  it('returns null contractPackage for a package hash not in the map', () => {
+    const dto2 = new EIP712SignatureRequestDto({
+      typedData,
+      signingPublicKeyHex: SIGNING_PK,
+      network: 'mainnet',
+      digest: '0xd2',
+      accountInfoMap: {},
+      contractPackageMap: {}, // empty map — no package enrichment
+      enrichment: { accounts: 'ok', contractPackage: 'absent' },
+    });
+    expect(dto2.domainRows.find(r => r.label === 'Package Hash')!.contractPackage).toBeNull();
   });
 });

--- a/src/data/dto/eip712/EIP712SignatureRequestDto.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../domain';
 import { buildTypedDataEIP712DisplayModel } from '../../../utils';
 import { deriveKeyType, getAccountInfoFromMap } from '../common';
-import { EIP712_CHAIN_NAME_KEY, resolveEip712AddressToAccountHash } from './common';
+import { EIP712_CHAIN_NAME_KEY } from './common';
 
 export interface IEIP712SignatureRequestDtoProps {
   typedData: IEIP712TypedData;
@@ -21,7 +21,7 @@ export interface IEIP712SignatureRequestDtoProps {
   digest: string;
   hashArtifacts?: IEIP712HashArtifacts;
   accountInfoMap: Record<string, IAccountInfo>;
-  contractPackage: Maybe<IContractPackage>;
+  contractPackageMap: Record<string, IContractPackage>;
   enrichment: IEIP712Enrichment;
 }
 
@@ -47,21 +47,15 @@ export class EIP712SignatureRequestDto implements IEIP712SignatureRequest {
     digest,
     hashArtifacts,
     accountInfoMap,
-    contractPackage,
+    contractPackageMap,
     enrichment,
   }: IEIP712SignatureRequestDtoProps) {
     const { domainRows, messageRows } = buildTypedDataEIP712DisplayModel(
       typedData,
       {
-        resolveAccountInfo: value => {
-          // address values may be a Casper public key or account hash — resolve to account hash first,
-          // then look up by it so the key matches what getAccountHashesFromTypedDataEIP712 fetched.
-          const accountHash = resolveEip712AddressToAccountHash(value);
-          return accountHash
-            ? (getAccountInfoFromMap(accountInfoMap, accountHash, 'accountHash') ?? null)
-            : null;
-        },
-        contractPackage,
+        resolveAccountInfo: accountHash =>
+          getAccountInfoFromMap(accountInfoMap, accountHash, 'accountHash') ?? null,
+        resolveContractPackage: packageHash => contractPackageMap[packageHash] ?? null,
       },
       [EIP712_CHAIN_NAME_KEY],
     );

--- a/src/data/dto/eip712/common.test.ts
+++ b/src/data/dto/eip712/common.test.ts
@@ -1,6 +1,6 @@
 import {
   getAccountHashesFromTypedDataEIP712,
-  resolveEip712AddressToAccountHash,
+  getPackageHashesFromTypedDataEIP712,
   stripHexPrefix,
 } from './common';
 import { getAccountHashFromPublicKey } from '../../../utils';
@@ -73,36 +73,52 @@ describe('stripHexPrefix', () => {
   });
 });
 
-describe('resolveEip712AddressToAccountHash', () => {
-  // valid secp256k1 (02-prefixed, 68 hex) public key
-  const SECP_PK = '0202466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27';
+const ACC = 'a'.repeat(64);
+const PKG = 'b'.repeat(64);
 
-  it('strips 0x and resolves an ed25519 public key to its account hash', () => {
-    const expected = getAccountHashFromPublicKey(SIGNING_PK);
-    expect(resolveEip712AddressToAccountHash(SIGNING_PK)).toBe(expected);
-    expect(resolveEip712AddressToAccountHash('0x' + SIGNING_PK)).toBe(expected);
+describe('getAccountHashesFromTypedDataEIP712 — account-tagged only + signer', () => {
+  const typedDataTagged = {
+    domain: {},
+    types: {
+      Transfer: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+      ],
+    },
+    primaryType: 'Transfer',
+    message: { from: '00' + ACC, to: '01' + PKG, value: '1' },
+  };
+
+  it('collects only account-tagged addresses plus the signer hash', () => {
+    const hashes = getAccountHashesFromTypedDataEIP712(typedDataTagged, SIGNING_PK);
+    expect(hashes).toContain(ACC); // account-tagged `from`
+    expect(hashes).not.toContain(PKG); // package-tagged `to` excluded
+    expect(hashes.length).toBeGreaterThanOrEqual(2); // ACC + signer
   });
 
-  it('resolves a secp256k1 (02-prefixed) public key to its account hash', () => {
-    const expected = getAccountHashFromPublicKey(SECP_PK);
-    expect(resolveEip712AddressToAccountHash(SECP_PK)).toBe(expected);
-    expect(resolveEip712AddressToAccountHash('0x' + SECP_PK)).toBe(expected);
+  it('includes the signer account hash derived from the signing public key', () => {
+    const hashes = getAccountHashesFromTypedDataEIP712(typedDataTagged, SIGNING_PK);
+    expect(hashes).toContain(getAccountHashFromPublicKey(SIGNING_PK));
   });
+});
 
-  it('returns a 64-hex account-hash value unchanged (minus 0x)', () => {
-    const acct = 'c'.repeat(64);
-    expect(resolveEip712AddressToAccountHash(acct)).toBe(acct);
-    expect(resolveEip712AddressToAccountHash('0x' + acct)).toBe(acct);
-  });
-
-  it('returns null for an ETH-style 20-byte (40-hex) address', () => {
-    expect(resolveEip712AddressToAccountHash('0x' + 'ab'.repeat(20))).toBeNull();
-    expect(resolveEip712AddressToAccountHash('ab'.repeat(20))).toBeNull();
-  });
-
-  it('returns null for a non-hex / junk value', () => {
-    expect(resolveEip712AddressToAccountHash('not-an-address')).toBeNull();
-    expect(resolveEip712AddressToAccountHash('z'.repeat(64))).toBeNull();
-    expect(resolveEip712AddressToAccountHash('')).toBeNull();
+describe('getPackageHashesFromTypedDataEIP712', () => {
+  it('collects the domain package hash and package-tagged message addresses', () => {
+    const typedDataPkg = {
+      domain: { contract_package_hash: '0x' + PKG },
+      types: {
+        Transfer: [
+          { name: 'from', type: 'address' },
+          { name: 'to', type: 'address' },
+        ],
+      },
+      primaryType: 'Transfer',
+      message: { from: '00' + ACC, to: '01' + 'c'.repeat(64) },
+    };
+    const hashes = getPackageHashesFromTypedDataEIP712(typedDataPkg);
+    expect(hashes).toContain(PKG); // domain (0x stripped)
+    expect(hashes).toContain('c'.repeat(64)); // package-tagged `to`
+    expect(hashes).not.toContain(ACC); // account `from` excluded
   });
 });

--- a/src/data/dto/eip712/common.ts
+++ b/src/data/dto/eip712/common.ts
@@ -1,6 +1,7 @@
 import { IEIP712Field, IEIP712TypedData } from '../../../domain';
 import { Maybe } from '../../../typings';
 import { getHashByType } from '../common';
+import { decodeEip712Address } from '../../../utils/eip712';
 
 /**
  * The EIP-712 domain key carrying the chain name. It is promoted to the dedicated
@@ -14,31 +15,11 @@ export const EIP712_CHAIN_NAME_KEY = 'chain_name';
 export const stripHexPrefix = (value: string): string =>
   value.startsWith('0x') ? value.slice(2) : value;
 
-/** A bare Casper account hash: exactly 64 hex chars. */
-const ACCOUNT_HASH_REGEX = /^[\da-fA-F]{64}$/;
-
 /**
- * Resolve an EIP-712 `address` field value to a Casper account hash. The value may be a Casper public
- * key (01/02-prefixed, 66/68 hex) or a bare account hash (64 hex), with an optional `0x` prefix.
- * Returns null when it cannot be resolved — including values that are neither (e.g. an ETH-style
- * 20-byte address or junk). This keeps a bad row from poisoning the whole batched `getAccountsInfo`
- * call: `getAccountHashesFromTypedDataEIP712` drops nulls, so enrichment degrades per-row, not per-request.
- */
-export const resolveEip712AddressToAccountHash = (rawValue: string): Maybe<string> => {
-  const value = stripHexPrefix(String(rawValue));
-  const isPublicKey =
-    (value.startsWith('01') && value.length === 66) ||
-    (value.startsWith('02') && value.length === 68);
-  if (isPublicKey) {
-    return getHashByType(value, 'publicKey');
-  }
-  return ACCOUNT_HASH_REGEX.test(value) ? value : null;
-};
-
-/**
- * Account hashes to resolve for a typed-data request: every `address`-typed field value across the
- * domain and the primary-type message (resolved to account hashes), plus the signing key.
- * Deduplicated; null/empty results dropped.
+ * Account hashes to resolve for a typed-data request: every account-tagged (`0x00`) `address`-typed
+ * field value across the domain and the primary-type message, plus the signing key's account hash.
+ * Package-tagged (`0x01`) and unknown-tagged addresses are excluded — those are collected separately
+ * by `getPackageHashesFromTypedDataEIP712`. Deduplicated; null/empty results dropped.
  */
 export const getAccountHashesFromTypedDataEIP712 = (
   typedData: IEIP712TypedData,
@@ -50,7 +31,10 @@ export const getAccountHashesFromTypedDataEIP712 = (
     (fields ?? []).forEach(({ name, type }) => {
       const value = source[name];
       if (type === 'address' && typeof value === 'string' && value) {
-        hashes.push(resolveEip712AddressToAccountHash(value));
+        const decoded = decodeEip712Address(value);
+        if (decoded.kind === 'account') {
+          hashes.push(decoded.hash);
+        }
       }
     });
   };
@@ -58,6 +42,32 @@ export const getAccountHashesFromTypedDataEIP712 = (
   collect(typedData.types.EIP712Domain, typedData.domain);
   collect(typedData.types[typedData.primaryType], typedData.message);
   hashes.push(getHashByType(signingPublicKeyHex, 'publicKey'));
+
+  return Array.from(new Set(hashes.filter((h): h is string => Boolean(h))));
+};
+
+/**
+ * Package hashes to resolve for a typed-data request: the domain `contract_package_hash` (stripped
+ * of `0x`) plus every package-tagged (`0x01`) `address`-typed field value in the primary-type message.
+ * Deduplicated; null/empty results dropped.
+ */
+export const getPackageHashesFromTypedDataEIP712 = (typedData: IEIP712TypedData): string[] => {
+  const hashes: Array<Maybe<string>> = [];
+
+  const domainPackage = typedData.domain.contract_package_hash;
+  if (typeof domainPackage === 'string' && domainPackage) {
+    hashes.push(stripHexPrefix(domainPackage));
+  }
+
+  (typedData.types[typedData.primaryType] ?? []).forEach(({ name, type }) => {
+    const value = typedData.message[name];
+    if (type === 'address' && typeof value === 'string' && value) {
+      const decoded = decodeEip712Address(value);
+      if (decoded.kind === 'package') {
+        hashes.push(decoded.hash);
+      }
+    }
+  });
 
   return Array.from(new Set(hashes.filter((h): h is string => Boolean(h))));
 };

--- a/src/data/repositories/eip712/eip712.test.ts
+++ b/src/data/repositories/eip712/eip712.test.ts
@@ -122,6 +122,27 @@ describe('EIP712Repository', () => {
     expect(req.enrichment).toEqual({ accounts: 'ok', contractPackage: 'ok' });
   });
 
+  it('calls getContractPackage once per unique package hash', async () => {
+    const { repo: r, accountInfoRepository, contractPackageRepository } = buildRepo();
+    jest.spyOn(accountInfoRepository, 'getAccountsInfo').mockResolvedValue({});
+    const pkgSpy = jest
+      .spyOn(contractPackageRepository, 'getContractPackage')
+      .mockResolvedValue(null);
+
+    // TYPED_DATA has domain contract_package_hash ('01'.repeat(32))
+    // and a package-tagged spender ('0x01' + '03'.repeat(32))
+    // so 2 unique package hashes → 2 calls
+    await r.prepareSignatureRequest({ typedData: TYPED_DATA, signingPublicKeyHex: SIGNING_PK });
+
+    expect(pkgSpy).toHaveBeenCalledTimes(2);
+    expect(pkgSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ contractPackageHash: '01'.repeat(32) }),
+    );
+    expect(pkgSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ contractPackageHash: '03'.repeat(32) }),
+    );
+  });
+
   it('calls the lookups with deduped hashes, mapped network, proxy flag and 0x-stripped hash', async () => {
     const { repo: r, accountInfoRepository, contractPackageRepository } = buildRepo();
     const accountsSpy = jest.spyOn(accountInfoRepository, 'getAccountsInfo').mockResolvedValue({});
@@ -137,11 +158,14 @@ describe('EIP712Repository', () => {
     expect(accountsArg.accountHashes).toContain(getAccountHashFromPublicKey(SIGNING_PK));
     expect(new Set(accountsArg.accountHashes).size).toBe(accountsArg.accountHashes.length);
 
-    expect(pkgSpy).toHaveBeenCalledWith({
-      contractPackageHash: '01'.repeat(32), // 0x stripped
-      network: 'mainnet',
-      withProxyHeader: true,
-    });
+    // Domain package hash should be called with 0x stripped
+    expect(pkgSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractPackageHash: '01'.repeat(32), // 0x stripped
+        network: 'mainnet',
+        withProxyHeader: true,
+      }),
+    );
   });
 
   it('feeds a non-empty account map through to the DTO (repo→DTO keying)', async () => {
@@ -257,7 +281,7 @@ describe('EIP712Repository', () => {
     expect(req.network).toBe('mainnet');
   });
 
-  it('marks contractPackage absent when the domain has no contract_package_hash', async () => {
+  it('marks contractPackage absent when there are no package hashes at all', async () => {
     const { repo: r, accountInfoRepository, contractPackageRepository } = buildRepo();
     jest.spyOn(accountInfoRepository, 'getAccountsInfo').mockResolvedValue({});
     const pkgSpy = jest.spyOn(contractPackageRepository, 'getContractPackage');
@@ -265,7 +289,15 @@ describe('EIP712Repository', () => {
       domain: { name: 'CasperSwap', version: '1', chain_name: 'casper' },
       types: PermitTypes,
       primaryType: 'Permit',
-      message: MESSAGE,
+      // MESSAGE has a package-tagged spender ('0x01' + '03'.repeat(32)) —
+      // use a message with no package addresses and no domain package hash
+      message: {
+        owner: '0x00' + '02'.repeat(32),
+        spender: '0x00' + '04'.repeat(32), // account-tagged, not package
+        value: 1000n,
+        nonce: 0n,
+        deadline: 1999999999n,
+      },
     };
 
     const req = await r.prepareSignatureRequest({

--- a/src/data/repositories/eip712/eip712.test.ts
+++ b/src/data/repositories/eip712/eip712.test.ts
@@ -226,6 +226,34 @@ describe('EIP712Repository', () => {
     );
   });
 
+  it('reports contractPackage as partial when some lookups succeed and others throw', async () => {
+    const { repo: r, accountInfoRepository, contractPackageRepository, logger } = buildRepo();
+    const err = new Error('pkg');
+    jest.spyOn(accountInfoRepository, 'getAccountsInfo').mockResolvedValue({});
+    // Two unique package hashes: domain ('01'…) resolves, message-tagged ('03'…) throws.
+    jest
+      .spyOn(contractPackageRepository, 'getContractPackage')
+      .mockImplementation(async ({ contractPackageHash }) => {
+        if (contractPackageHash === '03'.repeat(32)) {
+          throw err;
+        }
+        return pkg;
+      });
+
+    const req = await r.prepareSignatureRequest({
+      typedData: TYPED_DATA,
+      signingPublicKeyHex: SIGNING_PK,
+    });
+
+    expect(req.enrichment).toEqual({ accounts: 'ok', contractPackage: 'partial' });
+    // The resolved package is still mapped; the failed one is silently absent.
+    expect(req.domainRows.find(row => row.label === 'Package Hash')!.contractPackage).toEqual(pkg);
+    expect(logger.reportError).toHaveBeenCalledWith(
+      err,
+      expect.stringContaining('getContractPackage'),
+    );
+  });
+
   it('skips lookups when the network is unmappable and none is provided', async () => {
     const { repo: r, accountInfoRepository, contractPackageRepository } = buildRepo();
     const spy = jest.spyOn(accountInfoRepository, 'getAccountsInfo').mockResolvedValue({});

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -135,28 +135,37 @@ export class EIP712Repository implements IEIP712Repository {
       if (packageHashes.length === 0) {
         contractPackageStatus = 'absent';
       } else {
-        let anyOk = false;
-        let anyFailed = false;
-        for (const packageHash of packageHashes) {
-          try {
-            const pkg = await this._contractPackageRepository.getContractPackage({
+        // Independent lookups — run in parallel, but keep per-package isolation so one failure
+        // doesn't reject the batch (unlike account info, which is a single batched call).
+        const results = await Promise.allSettled(
+          packageHashes.map(packageHash =>
+            this._contractPackageRepository.getContractPackage({
               contractPackageHash: packageHash,
               network,
               withProxyHeader,
-            });
-            if (pkg) {
-              contractPackageMap[packageHash] = pkg;
+            }),
+          ),
+        );
+
+        let anyOk = false;
+        let anyFailed = false;
+        results.forEach((result, i) => {
+          if (result.status === 'fulfilled') {
+            if (result.value) {
+              contractPackageMap[packageHashes[i]] = result.value;
             }
             anyOk = true;
-          } catch (e) {
+          } else {
             anyFailed = true;
             this._logger.reportError(
-              e,
+              result.reason,
               'EIP712Repository.prepareSignatureRequest: getContractPackage',
             );
           }
-        }
-        contractPackageStatus = anyOk ? 'ok' : anyFailed ? 'failed' : 'absent';
+        });
+        // Distinguish a degraded `partial` (some succeeded, some threw) from a clean `ok`/`failed`,
+        // so consumers can surface a partial-enrichment warning instead of trusting a coarse `ok`.
+        contractPackageStatus = anyOk ? (anyFailed ? 'partial' : 'ok') : 'failed';
       }
     }
 

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -21,7 +21,6 @@ import {
   IPrepareEIP712SignatureRequestParams,
   isEIP712Error,
 } from '../../../domain';
-import { Maybe } from '../../../typings';
 import {
   buildTypedDataEIP712DisplayModel,
   computeTypedDataEIP712Digest,
@@ -35,7 +34,7 @@ import {
   EIP712_CHAIN_NAME_KEY,
   EIP712SignatureRequestDto,
   getAccountHashesFromTypedDataEIP712,
-  stripHexPrefix,
+  getPackageHashesFromTypedDataEIP712,
 } from '../../dto';
 
 /**
@@ -110,7 +109,7 @@ export class EIP712Repository implements IEIP712Repository {
       null;
 
     let accountInfoMap: Record<string, IAccountInfo> = {};
-    let contractPackage: Maybe<IContractPackage> = null;
+    let contractPackageMap: Record<string, IContractPackage> = {};
     let accounts: EIP712EnrichmentStatus = 'skipped';
     let contractPackageStatus: EIP712ContractEnrichmentStatus = 'skipped';
 
@@ -132,24 +131,32 @@ export class EIP712Repository implements IEIP712Repository {
         this._logger.reportError(e, 'EIP712Repository.prepareSignatureRequest: getAccountsInfo');
       }
 
-      const contractPackageHash = typedData.domain.contract_package_hash;
-      if (contractPackageHash) {
-        try {
-          contractPackage = await this._contractPackageRepository.getContractPackage({
-            contractPackageHash: stripHexPrefix(String(contractPackageHash)),
-            network,
-            withProxyHeader,
-          });
-          contractPackageStatus = 'ok';
-        } catch (e) {
-          contractPackageStatus = 'failed';
-          this._logger.reportError(
-            e,
-            'EIP712Repository.prepareSignatureRequest: getContractPackage',
-          );
-        }
-      } else {
+      const packageHashes = getPackageHashesFromTypedDataEIP712(typedData);
+      if (packageHashes.length === 0) {
         contractPackageStatus = 'absent';
+      } else {
+        let anyOk = false;
+        let anyFailed = false;
+        for (const packageHash of packageHashes) {
+          try {
+            const pkg = await this._contractPackageRepository.getContractPackage({
+              contractPackageHash: packageHash,
+              network,
+              withProxyHeader,
+            });
+            if (pkg) {
+              contractPackageMap[packageHash] = pkg;
+            }
+            anyOk = true;
+          } catch (e) {
+            anyFailed = true;
+            this._logger.reportError(
+              e,
+              'EIP712Repository.prepareSignatureRequest: getContractPackage',
+            );
+          }
+        }
+        contractPackageStatus = anyOk ? 'ok' : anyFailed ? 'failed' : 'absent';
       }
     }
 
@@ -161,7 +168,7 @@ export class EIP712Repository implements IEIP712Repository {
         digest,
         hashArtifacts,
         accountInfoMap,
-        contractPackage,
+        contractPackageMap,
         enrichment: { accounts, contractPackage: contractPackageStatus },
       });
     } catch (e) {

--- a/src/domain/eip712/entities.ts
+++ b/src/domain/eip712/entities.ts
@@ -60,13 +60,19 @@ export interface IEIP712DisplayModel {
 
 /** Outcome of a best-effort enrichment lookup, so consumers can tell a failed lookup from absent data. */
 export type EIP712EnrichmentStatus = 'ok' | 'failed' | 'skipped';
-/** Contract-package enrichment adds `absent` for "no `contract_package_hash` in the domain". */
-export type EIP712ContractEnrichmentStatus = EIP712EnrichmentStatus | 'absent';
+/**
+ * Contract-package enrichment adds `absent` ("no `contract_package_hash` in the domain") and
+ * `partial` (some package lookups succeeded while others threw — degraded, not fully failed).
+ */
+export type EIP712ContractEnrichmentStatus = EIP712EnrichmentStatus | 'absent' | 'partial';
 
 export interface IEIP712Enrichment {
   /** Account-info batch: `skipped` (no network), `ok` (batch succeeded), `failed` (batch threw). */
   accounts: EIP712EnrichmentStatus;
-  /** Contract package: `skipped`, `absent`, `ok` (lookup completed), `failed` (lookup threw). */
+  /**
+   * Contract package: `skipped`, `absent`, `ok` (all lookups completed), `partial` (some succeeded,
+   * some threw), `failed` (every lookup threw).
+   */
   contractPackage: EIP712ContractEnrichmentStatus;
 }
 

--- a/src/domain/eip712/entities.ts
+++ b/src/domain/eip712/entities.ts
@@ -39,7 +39,7 @@ export interface IEIP712Digest {
   hashArtifacts?: IEIP712HashArtifacts;
 }
 
-export type EIP712FieldPresentation = 'hash' | 'number' | 'account' | 'string';
+export type EIP712FieldPresentation = 'hash' | 'number' | 'account' | 'string' | 'date';
 
 export interface IEIP712DisplayRow {
   label: string;

--- a/src/utils/casperSdk/index.test.ts
+++ b/src/utils/casperSdk/index.test.ts
@@ -41,6 +41,11 @@ describe('casperSdk helpers', () => {
     it('returns null for unknown chain', () => {
       expect(getCasperNetworkByChainName('bogus')).toBeNull();
     });
+
+    it('resolves a CAIP-2 chain name by its reference segment', () => {
+      expect(getCasperNetworkByChainName('casper:casper-test')).toBe('testnet');
+      expect(getCasperNetworkByChainName('casper:casper')).toBe('mainnet');
+    });
   });
 
   describe('getBlockExplorerAccountUrl', () => {

--- a/src/utils/casperSdk/index.ts
+++ b/src/utils/casperSdk/index.ts
@@ -1,4 +1,4 @@
-import { CasperNetworkName, PublicKey } from 'casper-js-sdk';
+import { PublicKey } from 'casper-js-sdk';
 import { casperChainNameToCasperNetwork, CasperLiveUrl, CasperNetwork } from '../../domain';
 import { Maybe } from '../../typings';
 
@@ -15,15 +15,24 @@ import { Maybe } from '../../typings';
 export const getAccountHashFromPublicKey = (publicKey: string): string =>
   PublicKey.fromHex(publicKey).accountHash().toHex();
 
-/** Accepts CasperNetwork and CasperNetworkName chainNames */
-export const getCasperNetworkByChainName = (chainName: string): Maybe<CasperNetwork> => {
-  const networks: CasperNetwork[] = ['mainnet', 'testnet', 'devnet', 'integration'];
+const CASPER_NETWORKS = new Set<string>(['mainnet', 'testnet', 'devnet', 'integration']);
 
-  if (networks.includes(chainName as CasperNetwork)) {
-    return chainName as CasperNetwork;
+const isCasperNetwork = (value: string): value is CasperNetwork => CASPER_NETWORKS.has(value);
+
+/** Accepts CasperNetwork and CasperNetworkName chainNames, incl. CAIP-2 (e.g. "casper:casper-test"). */
+export const getCasperNetworkByChainName = (chainName: string): Maybe<CasperNetwork> => {
+  // CAIP-2 (e.g. "casper:casper-test") — use the reference segment after the last ':'.
+  const name = chainName.includes(':')
+    ? chainName.slice(chainName.lastIndexOf(':') + 1)
+    : chainName;
+
+  if (isCasperNetwork(name)) {
+    return name;
   }
 
-  return casperChainNameToCasperNetwork[chainName as CasperNetworkName] ?? null;
+  // Dynamic string lookup into a Record<CasperNetworkName, CasperNetwork>: widen the key type
+  // instead of asserting `name` is a valid enum member.
+  return (casperChainNameToCasperNetwork as Record<string, CasperNetwork>)[name] ?? null;
 };
 
 export const getBlockExplorerAccountUrl = (

--- a/src/utils/eip712/address.test.ts
+++ b/src/utils/eip712/address.test.ts
@@ -1,0 +1,26 @@
+import { decodeEip712Address } from './address';
+
+const HASH = 'a'.repeat(64);
+
+describe('decodeEip712Address', () => {
+  it('decodes a 0x00-tagged account address', () => {
+    expect(decodeEip712Address('00' + HASH)).toEqual({ kind: 'account', hash: HASH });
+    expect(decodeEip712Address('0x00' + HASH)).toEqual({ kind: 'account', hash: HASH });
+  });
+  it('decodes a 0x01-tagged package address', () => {
+    expect(decodeEip712Address('01' + HASH)).toEqual({ kind: 'package', hash: HASH });
+  });
+  it('treats a bare 32-byte hash as an account', () => {
+    expect(decodeEip712Address(HASH)).toEqual({ kind: 'account', hash: HASH });
+    expect(decodeEip712Address('0x' + HASH)).toEqual({ kind: 'account', hash: HASH });
+  });
+  it('returns unknown for an unrecognized tag or wrong length', () => {
+    expect(decodeEip712Address('02' + HASH)).toEqual({ kind: 'unknown', hash: null });
+    expect(decodeEip712Address('ab'.repeat(20))).toEqual({ kind: 'unknown', hash: null });
+    expect(decodeEip712Address('not-an-address')).toEqual({ kind: 'unknown', hash: null });
+    expect(decodeEip712Address('')).toEqual({ kind: 'unknown', hash: null });
+  });
+  it('is case-insensitive on the hex body', () => {
+    expect(decodeEip712Address('00' + 'A'.repeat(64))).toEqual({ kind: 'account', hash: HASH });
+  });
+});

--- a/src/utils/eip712/address.ts
+++ b/src/utils/eip712/address.ts
@@ -1,0 +1,34 @@
+import { Maybe } from '../../typings';
+
+export type Eip712AddressKind = 'account' | 'package' | 'unknown';
+
+export interface IEip712DecodedAddress {
+  /** 'account' = 0x00 tag, 'package' = 0x01 tag, 'unknown' = unrecognized. */
+  kind: Eip712AddressKind;
+  /** 32-byte hash (64 hex, no tag) for account/package; null for unknown. */
+  hash: Maybe<string>;
+}
+
+const HEX_33_BYTES = /^[\da-f]{66}$/;
+const HEX_32_BYTES = /^[\da-f]{64}$/;
+
+const strip0x = (value: string): string => (value.startsWith('0x') ? value.slice(2) : value);
+
+/**
+ * Decode an EIP-712 `address` value per CEP-2612/CEP-3009: a 33-byte Casper Key
+ * (1-byte tag + 32-byte hash), tag 0x00 = AccountHash, 0x01 = contract package Hash.
+ * A bare 32-byte hash is treated leniently as an account hash. Public keys are NOT
+ * accepted here — the 0x01 tag means a package, never an ed25519 key.
+ */
+export const decodeEip712Address = (rawValue: string): IEip712DecodedAddress => {
+  const value = strip0x(String(rawValue)).toLowerCase();
+  if (HEX_33_BYTES.test(value)) {
+    const tag = value.slice(0, 2);
+    const hash = value.slice(2);
+    if (tag === '00') return { kind: 'account', hash };
+    if (tag === '01') return { kind: 'package', hash };
+    return { kind: 'unknown', hash: null };
+  }
+  if (HEX_32_BYTES.test(value)) return { kind: 'account', hash: value };
+  return { kind: 'unknown', hash: null };
+};

--- a/src/utils/eip712/displayModel.test.ts
+++ b/src/utils/eip712/displayModel.test.ts
@@ -1,5 +1,6 @@
 import {
   buildTypedDataEIP712DisplayModel,
+  formatEip712Date,
   getPresentationForType,
   keyToLabel,
 } from './displayModel';
@@ -35,6 +36,9 @@ describe('keyToLabel', () => {
   });
   it('title-cases snake_case otherwise', () => {
     expect(keyToLabel('chain_name')).toBe('Chain Name');
+  });
+  it('splits camelCase field names', () => {
+    expect(keyToLabel('validAfter')).toBe('Valid After');
   });
 });
 
@@ -143,5 +147,86 @@ describe('buildTypedDataEIP712DisplayModel', () => {
     expect(model.domainRows.find(r => r.label === 'Chain Name')).toBeUndefined();
     expect(model.domainRows.find(r => r.label === 'Package Hash')).toBeDefined();
     expect(model.messageRows.find(r => r.label === 'Owner')).toBeDefined();
+  });
+});
+
+describe('formatEip712Date', () => {
+  it('formats unix seconds', () => {
+    // 2026-06-23T21:00:00Z = 1782680400 s
+    const out = formatEip712Date('1782680400');
+    expect(out).not.toBeNull();
+    expect(out).toContain('2026');
+  });
+  it('treats values >= 1e12 as milliseconds', () => {
+    expect(formatEip712Date('1782680400000')).toContain('2026');
+  });
+  it('returns null for non-numeric, non-positive, or invalid input', () => {
+    expect(formatEip712Date('not-a-number')).toBeNull();
+    expect(formatEip712Date('0')).toBeNull();
+    expect(formatEip712Date('-5')).toBeNull();
+  });
+  it('returns null when the value is past the representable Date range', () => {
+    expect(formatEip712Date('1e30')).toBeNull();
+  });
+});
+
+describe('buildTypedDataEIP712DisplayModel — dates', () => {
+  const base = {
+    domain: { chain_name: 'casper' },
+    types: {
+      EIP712Domain: [{ name: 'chain_name', type: 'string' }],
+      Auth: [
+        { name: 'validAfter', type: 'uint256' },
+        { name: 'validBefore', type: 'uint256' },
+        { name: 'value', type: 'uint256' },
+        { name: 'note', type: 'string' },
+      ],
+    },
+    primaryType: 'Auth',
+    message: {
+      validAfter: '1782680400',
+      validBefore: '1782684000',
+      value: '1000',
+      note: 'hi',
+    },
+  };
+
+  it('renders known timestamp fields as date presentation', () => {
+    const model = buildTypedDataEIP712DisplayModel(base);
+    const va = model.messageRows.find(r => r.label === 'Valid After')!;
+    expect(va.presentation).toBe('date');
+    expect(va.displayValue).not.toBe('1782680400');
+    expect(va.displayValue).toContain('2026');
+    expect(va.copyValue).toBeNull();
+    expect(model.messageRows.find(r => r.label === 'Valid Before')!.presentation).toBe('date');
+  });
+
+  it('leaves a non-timestamp numeric field as number', () => {
+    const value = buildTypedDataEIP712DisplayModel(base).messageRows.find(
+      r => r.label === 'Value',
+    )!;
+    expect(value.presentation).toBe('number');
+    expect(value.displayValue).toBe('1000');
+  });
+
+  it('does not treat a date-named non-numeric field as a date', () => {
+    const td = {
+      ...base,
+      types: { ...base.types, Auth: [{ name: 'validAfter', type: 'string' }] },
+      message: { validAfter: 'soon' },
+    };
+    const row = buildTypedDataEIP712DisplayModel(td).messageRows.find(
+      r => r.label === 'Valid After',
+    )!;
+    expect(row.presentation).toBe('string');
+  });
+
+  it('falls back to number when a timestamp value is unparseable', () => {
+    const td = { ...base, message: { ...base.message, validAfter: 'oops' } };
+    const row = buildTypedDataEIP712DisplayModel(td).messageRows.find(
+      r => r.label === 'Valid After',
+    )!;
+    expect(row.presentation).toBe('number');
+    expect(row.displayValue).toBe('oops');
   });
 });

--- a/src/utils/eip712/displayModel.test.ts
+++ b/src/utils/eip712/displayModel.test.ts
@@ -263,6 +263,28 @@ describe('buildTypedDataEIP712DisplayModel — date sentinels & trim', () => {
     expect(model.messageRows.find(r => r.label === 'Valid Before')!.displayValue).toBe('No expiry');
   });
 
+  it('keys the sentinel label on field role, not just the value', () => {
+    const model = buildTypedDataEIP712DisplayModel(
+      td(
+        {
+          validAfter: '18446744073709551615',
+          validBefore: '0',
+          deadline: '0',
+        },
+        [
+          { name: 'validAfter', type: 'uint256' },
+          { name: 'validBefore', type: 'uint256' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      ),
+    );
+    // Lower bound at u64::MAX is never reachable, not "no expiry".
+    expect(model.messageRows.find(r => r.label === 'Valid After')!.displayValue).toBe('Never');
+    // Upper bound at 0 is already expired, not "always".
+    expect(model.messageRows.find(r => r.label === 'Valid Before')!.displayValue).toBe('Expired');
+    expect(model.messageRows.find(r => r.label === 'Deadline')!.displayValue).toBe('Expired');
+  });
+
   it('no longer treats validUntil/expiry as dates (trimmed)', () => {
     const row = buildTypedDataEIP712DisplayModel(
       td({ validUntil: '1782680400' }, [{ name: 'validUntil', type: 'uint256' }]),

--- a/src/utils/eip712/displayModel.test.ts
+++ b/src/utils/eip712/displayModel.test.ts
@@ -63,9 +63,10 @@ describe('buildTypedDataEIP712DisplayModel', () => {
   it('classifies presentation and leaves enrichment null on the sync path', () => {
     const model = buildTypedDataEIP712DisplayModel(typedData);
 
+    const pkgHashClean = '01'.repeat(32); // PKG_HASH with 0x stripped
     const pkg = model.domainRows.find(r => r.label === 'Package Hash')!;
     expect(pkg.presentation).toBe('hash');
-    expect(pkg.copyValue).toBe(PKG_HASH);
+    expect(pkg.copyValue).toBe(pkgHashClean); // 0x prefix stripped in new implementation
     expect(pkg.displayValue).not.toBe(PKG_HASH); // shortened
     expect(pkg.accountInfo).toBeNull();
     expect(pkg.contractPackage).toBeNull();
@@ -115,22 +116,33 @@ describe('buildTypedDataEIP712DisplayModel', () => {
       csprName: null,
       explorerLink: null,
     };
+    // PKG_HASH = '0x' + '01'.repeat(32); strip 0x -> '01'.repeat(32)
+    const pkgHashClean = '01'.repeat(32);
     const contractPackage = {
       id: 'c',
       latestVersionContractTypeId: 1,
-      contractPackageHash: PKG_HASH,
+      contractPackageHash: pkgHashClean,
       name: 'MyToken',
       iconUrl: null,
       symbol: 'MTK',
       decimals: 9,
     };
 
-    const model = buildTypedDataEIP712DisplayModel(typedData, {
-      resolveAccountInfo: value => (value === FULL_ADDR ? accountInfo : null),
-      contractPackage,
+    // Use '00' + FULL_ADDR so the decoder strips the tag and calls resolveAccountInfo(FULL_ADDR)
+    const tdWithTaggedOwner = {
+      ...typedData,
+      message: { ...typedData.message, owner: '00' + FULL_ADDR },
+    };
+
+    const model = buildTypedDataEIP712DisplayModel(tdWithTaggedOwner, {
+      resolveAccountInfo: h => (h === FULL_ADDR ? accountInfo : null),
+      resolveContractPackage: h => (h === pkgHashClean ? contractPackage : null),
     });
 
-    expect(model.messageRows.find(r => r.label === 'Owner')!.accountInfo).toEqual(accountInfo);
+    const ownerRow = model.messageRows.find(r => r.label === 'Owner')!;
+    expect(ownerRow.accountInfo).toEqual(accountInfo);
+    expect(ownerRow.value).toBe(FULL_ADDR); // tag stripped
+
     expect(model.domainRows.find(r => r.label === 'Package Hash')!.contractPackage).toEqual(
       contractPackage,
     );
@@ -167,6 +179,95 @@ describe('formatEip712Date', () => {
   });
   it('returns null when the value is past the representable Date range', () => {
     expect(formatEip712Date('1e30')).toBeNull();
+  });
+});
+
+describe('buildTypedDataEIP712DisplayModel — address kinds', () => {
+  const ACC = 'a'.repeat(64);
+  const PKG = 'b'.repeat(64);
+  const td = {
+    domain: {},
+    types: {
+      Transfer: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'other', type: 'address' },
+      ],
+    },
+    primaryType: 'Transfer',
+    message: { from: '00' + ACC, to: '01' + PKG, other: '02' + ACC },
+  };
+
+  it('renders an account address via resolveAccountInfo with the clean hash', () => {
+    const accountInfo = {
+      id: 'x',
+      publicKey: '01pk',
+      accountHash: ACC,
+      name: 'Alice',
+      brandingLogo: null,
+      csprName: null,
+      explorerLink: null,
+    };
+    const model = buildTypedDataEIP712DisplayModel(td, {
+      resolveAccountInfo: h => (h === ACC ? accountInfo : null),
+    });
+    const from = model.messageRows.find(r => r.label === 'From')!;
+    expect(from.presentation).toBe('account');
+    expect(from.value).toBe(ACC); // tag stripped
+    expect(from.copyValue).toBe(ACC);
+    expect(from.accountInfo).toEqual(accountInfo);
+  });
+
+  it('renders a package address via resolveContractPackage as a hash row', () => {
+    const pkg = {
+      id: 'c',
+      latestVersionContractTypeId: 1,
+      contractPackageHash: PKG,
+      name: 'Tok',
+      iconUrl: null,
+      symbol: 'T',
+      decimals: 9,
+    };
+    const to = buildTypedDataEIP712DisplayModel(td, {
+      resolveContractPackage: h => (h === PKG ? pkg : null),
+    }).messageRows.find(r => r.label === 'To')!;
+    expect(to.presentation).toBe('hash');
+    expect(to.value).toBe(PKG);
+    expect(to.contractPackage).toEqual(pkg);
+  });
+
+  it('renders an unknown-tag address as a raw hash row', () => {
+    const other = buildTypedDataEIP712DisplayModel(td).messageRows.find(r => r.label === 'Other')!;
+    expect(other.presentation).toBe('hash');
+    expect(other.contractPackage).toBeNull();
+    expect(other.accountInfo).toBeNull();
+  });
+});
+
+describe('buildTypedDataEIP712DisplayModel — date sentinels & trim', () => {
+  const td = (msg: Record<string, unknown>, fields: { name: string; type: string }[]) => ({
+    domain: {},
+    types: { Auth: fields },
+    primaryType: 'Auth',
+    message: msg,
+  });
+
+  it('shows "Always" for a 0 validAfter and "No expiry" for u64::MAX validBefore', () => {
+    const model = buildTypedDataEIP712DisplayModel(
+      td({ validAfter: '0', validBefore: '18446744073709551615' }, [
+        { name: 'validAfter', type: 'uint256' },
+        { name: 'validBefore', type: 'uint256' },
+      ]),
+    );
+    expect(model.messageRows.find(r => r.label === 'Valid After')!.displayValue).toBe('Always');
+    expect(model.messageRows.find(r => r.label === 'Valid Before')!.displayValue).toBe('No expiry');
+  });
+
+  it('no longer treats validUntil/expiry as dates (trimmed)', () => {
+    const row = buildTypedDataEIP712DisplayModel(
+      td({ validUntil: '1782680400' }, [{ name: 'validUntil', type: 'uint256' }]),
+    ).messageRows.find(r => r.label === 'Valid Until')!;
+    expect(row.presentation).toBe('number');
   });
 });
 

--- a/src/utils/eip712/displayModel.ts
+++ b/src/utils/eip712/displayModel.ts
@@ -1,4 +1,5 @@
 import { formatAddress } from '../address';
+import { formatDeployDetailsTimestamp } from '../date';
 import {
   EIP712FieldPresentation,
   IAccountInfo,
@@ -12,6 +13,36 @@ import { Maybe } from '../../typings';
 
 const BYTES_TYPE_REGEX = /^bytes(?:[1-9]|[12]\d|3[0-2])$/;
 const NUMBER_TYPE_REGEX = /^u?int\d*$/;
+
+const DATE_FIELD_NAMES = new Set([
+  'validafter',
+  'validbefore',
+  'validuntil',
+  'deadline',
+  'expiry',
+  'expiration',
+]);
+
+/** Unix values at/above this are already milliseconds; below are seconds. */
+const MS_THRESHOLD = 1e12;
+
+/** Format an EIP-712 unix timestamp (seconds, or ms when >= 1e12). Null on non-positive/unparseable. */
+export function formatEip712Date(value: string): Maybe<string> {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) {
+    return null;
+  }
+  const ms = num >= MS_THRESHOLD ? num : num * 1000;
+  const date = new Date(ms);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return formatDeployDetailsTimestamp(date.toISOString());
+}
+
+function isDateField(name: string, type: string): boolean {
+  return DATE_FIELD_NAMES.has(name.toLowerCase()) && NUMBER_TYPE_REGEX.test(type);
+}
 
 export function getPresentationForType(type: string): EIP712FieldPresentation {
   if (type === 'address') {
@@ -39,7 +70,10 @@ export function keyToLabel(key: string): string {
     case 'contract_package_hash':
       return 'Package Hash';
     default:
-      return key.replace(/_/g, ' ').replace(/\b\w/g, match => match.toUpperCase());
+      return key
+        .replace(/([a-z])([A-Z])/g, '$1 $2') // split camelCase: validAfter → valid After
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, match => match.toUpperCase());
   }
 }
 
@@ -64,7 +98,12 @@ function toRow(
   // `types.EIP712Domain` (so `type` is '') or send it as `string`, which would otherwise classify it
   // as 'string' and leave the value un-shortened and non-copyable. Force hash presentation by key.
   const isContractPackageHash = section === 'domain' && key === 'contract_package_hash';
-  const presentation = isContractPackageHash ? 'hash' : getPresentationForType(type);
+  const formattedDate = isDateField(key, type) ? formatEip712Date(value) : null;
+  const presentation: EIP712FieldPresentation = isContractPackageHash
+    ? 'hash'
+    : formattedDate
+      ? 'date'
+      : getPresentationForType(type);
   const isHashLike = presentation === 'hash' || presentation === 'account';
 
   const accountInfo =
@@ -79,7 +118,8 @@ function toRow(
   return {
     label: keyToLabel(key),
     value,
-    displayValue: isHashLike ? formatAddress(value, 'short') : value,
+    displayValue:
+      presentation === 'date' ? formattedDate! : isHashLike ? formatAddress(value, 'short') : value,
     presentation,
     type,
     copyValue: isHashLike ? value : null,

--- a/src/utils/eip712/displayModel.ts
+++ b/src/utils/eip712/displayModel.ts
@@ -15,7 +15,10 @@ import { decodeEip712Address } from './address';
 const BYTES_TYPE_REGEX = /^bytes(?:[1-9]|[12]\d|3[0-2])$/;
 const NUMBER_TYPE_REGEX = /^u?int\d*$/;
 
-const DATE_FIELD_NAMES = new Set(['validafter', 'validbefore', 'deadline']);
+// Lower-bound (valid-from) fields: 0 = valid since the epoch, u64::MAX = never reaches validity.
+const LOWER_BOUND_DATE_FIELDS = new Set(['validafter']);
+// Upper-bound (valid-until) fields: 0 = already expired, u64::MAX = no expiry.
+const UPPER_BOUND_DATE_FIELDS = new Set(['validbefore', 'deadline']);
 
 /** Unix values at/above this are already milliseconds; below are seconds. */
 const MS_THRESHOLD = 1e12;
@@ -38,23 +41,33 @@ export function formatEip712Date(value: string): Maybe<string> {
 // (e.g. casper-wallet), where BigInt literals are a TS2737 error.
 const U64_MAX = BigInt('18446744073709551615');
 
-/** Friendly text for EIP-712 timestamp sentinels, else null. */
-function dateSentinelLabel(value: string): Maybe<string> {
+/**
+ * Friendly text for EIP-712 timestamp sentinels, else null. The label depends on the field's role:
+ * the same 0 / u64::MAX value means the opposite for a lower bound (valid-from) vs an upper bound
+ * (valid-until), so a shared mapping would mislabel one of them in a signing UI.
+ */
+function dateSentinelLabel(name: string, value: string): Maybe<string> {
   if (value.trim() === '') {
     return null;
   }
+  let n: bigint;
   try {
-    const n = BigInt(value);
-    if (n === BigInt(0)) return 'Always';
-    if (n >= U64_MAX) return 'No expiry';
-    return null;
+    n = BigInt(value);
   } catch {
     return null;
   }
+  const isLowerBound = LOWER_BOUND_DATE_FIELDS.has(name.toLowerCase());
+  if (n === BigInt(0)) return isLowerBound ? 'Always' : 'Expired';
+  if (n >= U64_MAX) return isLowerBound ? 'Never' : 'No expiry';
+  return null;
 }
 
 function isDateField(name: string, type: string): boolean {
-  return DATE_FIELD_NAMES.has(name.toLowerCase()) && NUMBER_TYPE_REGEX.test(type);
+  const lower = name.toLowerCase();
+  return (
+    (LOWER_BOUND_DATE_FIELDS.has(lower) || UPPER_BOUND_DATE_FIELDS.has(lower)) &&
+    NUMBER_TYPE_REGEX.test(type)
+  );
 }
 
 export function getPresentationForType(type: string): EIP712FieldPresentation {
@@ -165,7 +178,7 @@ function toRow(
 
   // Known timestamp fields -> date (with sentinels), else fall through.
   if (isDateField(key, type)) {
-    const formatted = dateSentinelLabel(value) ?? formatEip712Date(value);
+    const formatted = dateSentinelLabel(key, value) ?? formatEip712Date(value);
     if (formatted) {
       return {
         label,

--- a/src/utils/eip712/displayModel.ts
+++ b/src/utils/eip712/displayModel.ts
@@ -10,18 +10,12 @@ import {
   IEIP712Types,
 } from '../../domain';
 import { Maybe } from '../../typings';
+import { decodeEip712Address } from './address';
 
 const BYTES_TYPE_REGEX = /^bytes(?:[1-9]|[12]\d|3[0-2])$/;
 const NUMBER_TYPE_REGEX = /^u?int\d*$/;
 
-const DATE_FIELD_NAMES = new Set([
-  'validafter',
-  'validbefore',
-  'validuntil',
-  'deadline',
-  'expiry',
-  'expiration',
-]);
+const DATE_FIELD_NAMES = new Set(['validafter', 'validbefore', 'deadline']);
 
 /** Unix values at/above this are already milliseconds; below are seconds. */
 const MS_THRESHOLD = 1e12;
@@ -38,6 +32,23 @@ export function formatEip712Date(value: string): Maybe<string> {
     return null;
   }
   return formatDeployDetailsTimestamp(date.toISOString());
+}
+
+const U64_MAX = 18446744073709551615n;
+
+/** Friendly text for EIP-712 timestamp sentinels, else null. */
+function dateSentinelLabel(value: string): Maybe<string> {
+  if (value.trim() === '') {
+    return null;
+  }
+  try {
+    const n = BigInt(value);
+    if (n === 0n) return 'Always';
+    if (n >= U64_MAX) return 'No expiry';
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 function isDateField(name: string, type: string): boolean {
@@ -80,11 +91,11 @@ export function keyToLabel(key: string): string {
 /**
  * @internal
  * Optional enrichment for display rows. `utils` stays free of `data`-layer imports: the data layer
- * passes a closure (over `getAccountInfoFromMap`) and the already-fetched contract package.
+ * passes closures keyed by the decoded hash (not the raw tagged value).
  */
 export interface IEIP712DisplayEnrichment {
-  resolveAccountInfo?: (rawValue: string) => Maybe<IAccountInfo>;
-  contractPackage?: Maybe<IContractPackage>;
+  resolveAccountInfo?: (accountHash: string) => Maybe<IAccountInfo>;
+  resolveContractPackage?: (packageHash: string) => Maybe<IContractPackage>;
 }
 
 function toRow(
@@ -94,37 +105,90 @@ function toRow(
   enrichment: IEIP712DisplayEnrichment,
   section: 'domain' | 'message',
 ): IEIP712DisplayRow {
-  // The domain `contract_package_hash` is semantically always a hash. Some payloads omit it from
-  // `types.EIP712Domain` (so `type` is '') or send it as `string`, which would otherwise classify it
-  // as 'string' and leave the value un-shortened and non-copyable. Force hash presentation by key.
-  const isContractPackageHash = section === 'domain' && key === 'contract_package_hash';
-  const formattedDate = isDateField(key, type) ? formatEip712Date(value) : null;
-  const presentation: EIP712FieldPresentation = isContractPackageHash
-    ? 'hash'
-    : formattedDate
-      ? 'date'
-      : getPresentationForType(type);
+  const label = keyToLabel(key);
+
+  // Domain contract_package_hash is a bytes32 (no Key tag) — always a package hash.
+  if (section === 'domain' && key === 'contract_package_hash') {
+    const packageHash = value.startsWith('0x') ? value.slice(2) : value;
+    return {
+      label,
+      value: packageHash,
+      displayValue: formatAddress(packageHash, 'short'),
+      presentation: 'hash',
+      type,
+      copyValue: packageHash,
+      accountInfo: null,
+      contractPackage: enrichment.resolveContractPackage?.(packageHash) ?? null,
+    };
+  }
+
+  // address fields are Casper Keys: 0x00 = account, 0x01 = package.
+  if (type === 'address') {
+    const { kind, hash } = decodeEip712Address(value);
+    if (kind === 'account' && hash) {
+      return {
+        label,
+        value: hash,
+        displayValue: formatAddress(hash, 'short'),
+        presentation: 'account',
+        type,
+        copyValue: hash,
+        accountInfo: enrichment.resolveAccountInfo?.(hash) ?? null,
+        contractPackage: null,
+      };
+    }
+    if (kind === 'package' && hash) {
+      return {
+        label,
+        value: hash,
+        displayValue: formatAddress(hash, 'short'),
+        presentation: 'hash',
+        type,
+        copyValue: hash,
+        accountInfo: null,
+        contractPackage: enrichment.resolveContractPackage?.(hash) ?? null,
+      };
+    }
+    return {
+      label,
+      value,
+      displayValue: formatAddress(value, 'short'),
+      presentation: 'hash',
+      type,
+      copyValue: value,
+      accountInfo: null,
+      contractPackage: null,
+    };
+  }
+
+  // Known timestamp fields -> date (with sentinels), else fall through.
+  if (isDateField(key, type)) {
+    const formatted = dateSentinelLabel(value) ?? formatEip712Date(value);
+    if (formatted) {
+      return {
+        label,
+        value,
+        displayValue: formatted,
+        presentation: 'date',
+        type,
+        copyValue: null,
+        accountInfo: null,
+        contractPackage: null,
+      };
+    }
+  }
+
+  const presentation = getPresentationForType(type);
   const isHashLike = presentation === 'hash' || presentation === 'account';
-
-  const accountInfo =
-    presentation === 'account' && enrichment.resolveAccountInfo
-      ? enrichment.resolveAccountInfo(value)
-      : null;
-  const contractPackage =
-    section === 'domain' && key === 'contract_package_hash'
-      ? (enrichment.contractPackage ?? null)
-      : null;
-
   return {
-    label: keyToLabel(key),
+    label,
     value,
-    displayValue:
-      presentation === 'date' ? formattedDate! : isHashLike ? formatAddress(value, 'short') : value,
+    displayValue: isHashLike ? formatAddress(value, 'short') : value,
     presentation,
     type,
     copyValue: isHashLike ? value : null,
-    accountInfo,
-    contractPackage,
+    accountInfo: null,
+    contractPackage: null,
   };
 }
 

--- a/src/utils/eip712/displayModel.ts
+++ b/src/utils/eip712/displayModel.ts
@@ -34,7 +34,9 @@ export function formatEip712Date(value: string): Maybe<string> {
   return formatDeployDetailsTimestamp(date.toISOString());
 }
 
-const U64_MAX = 18446744073709551615n;
+// BigInt() calls, not `n` literals: consumers compile this source under target es2017
+// (e.g. casper-wallet), where BigInt literals are a TS2737 error.
+const U64_MAX = BigInt('18446744073709551615');
 
 /** Friendly text for EIP-712 timestamp sentinels, else null. */
 function dateSentinelLabel(value: string): Maybe<string> {
@@ -43,7 +45,7 @@ function dateSentinelLabel(value: string): Maybe<string> {
   }
   try {
     const n = BigInt(value);
-    if (n === 0n) return 'Always';
+    if (n === BigInt(0)) return 'Always';
     if (n >= U64_MAX) return 'No expiry';
     return null;
   } catch {

--- a/src/utils/eip712/index.ts
+++ b/src/utils/eip712/index.ts
@@ -1,3 +1,4 @@
+export * from './address';
 export * from './validation';
 export * from './digest';
 export * from './displayModel';


### PR DESCRIPTION
## What

EIP-712 typed-data signing improvements for WALLET-1251, driven by QA feedback and the CEP-2612 / CEP-3009 specs.

## Changes

- **Address values decoded as Casper Keys** (CEP-2612 / CEP-3009): an EIP-712 `address` is a 33-byte Casper Key — `0x00` = account hash, `0x01` = contract package hash — not a public key. Previously a `0x01`-tagged package address was misidentified as an ed25519 public key. Account addresses are enriched via account info; package addresses are resolved as contract packages. A payload can carry several package addresses, so enrichment uses a `packageHash -> IContractPackage` map. New decoder in `utils/eip712/address.ts` (`decodeEip712Address`); no public-key derivation.
- **Date presentation**: known timestamp fields (`validAfter`, `validBefore`, `deadline`) render as human-readable dates; sentinels are labelled (`0` -> "Always", `u64::MAX` -> "No expiry").
- **CAIP-2 chain names**: `getCasperNetworkByChainName` resolves CAIP-2 names (e.g. `casper:casper-test`); refactored to a type guard instead of unsafe union casts.

## Notes

- Uses `BigInt(...)` calls (not literals) so consumers compiling this source under TS target es2017 (the wallet) build cleanly.

## Tests

Full jest suite green. New/updated tests cover address kinds, package enrichment, date trim + sentinels, and CAIP-2.