### PR TITLE
refactor(eip712): rename EIP712Repository.signTypedDataEIP712 to signTypedData

### DIFF
--- a/src/data/repositories/eip712/eip712.test.ts
+++ b/src/data/repositories/eip712/eip712.test.ts
@@ -55,9 +55,9 @@ describe('EIP712Repository', () => {
     expect(result.digest).toBe(EXPECTED_DIGEST);
   });
 
-  it('signTypedDataEIP712 computes then signs', () => {
+  it('signTypedData computes then signs', () => {
     const key = PrivateKey.fromHex('11'.repeat(32), KeyAlgorithm.SECP256K1);
-    const result = repo.signTypedDataEIP712({ typedData: TYPED_DATA, privateKey: key });
+    const result = repo.signTypedData({ typedData: TYPED_DATA, privateKey: key });
     expect(result.digest).toBe(EXPECTED_DIGEST);
   });
 

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -42,7 +42,7 @@ import {
  * contract-package data over HTTP (best-effort — each lookup is isolated in its own try/catch, so a
  * flaky API never breaks the request). The other methods are synchronous pure-CPU work.
  *
- * `computeDigest`, `signDigest` and `signTypedDataEIP712` wrap unexpected failures in {@link EIP712Error}.
+ * `computeDigest`, `signDigest` and `signTypedData` wrap unexpected failures in {@link EIP712Error}.
  * `prepareSignatureRequest` surfaces digest/validation failures as {@link EIP712Error} (via
  * `computeDigest`) and swallows enrichment-lookup failures (best-effort). `recoverSigner` and
  * `verifySignature` surface raw library errors.
@@ -74,7 +74,7 @@ export class EIP712Repository implements IEIP712Repository {
     }
   }
 
-  signTypedDataEIP712({
+  signTypedData({
     typedData,
     privateKey,
     options,

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -74,11 +74,7 @@ export class EIP712Repository implements IEIP712Repository {
     }
   }
 
-  signTypedData({
-    typedData,
-    privateKey,
-    options,
-  }: IEIP712SignTypedDataParams): IEIP712SignResult {
+  signTypedData({ typedData, privateKey, options }: IEIP712SignTypedDataParams): IEIP712SignResult {
     try {
       return signTypedDataEIP712Util(typedData, privateKey, options);
     } catch (e) {

--- a/src/domain/eip712/repository.ts
+++ b/src/domain/eip712/repository.ts
@@ -54,7 +54,7 @@ export interface IEIP712Repository {
   computeDigest(typedData: IEIP712TypedData, options?: IEIP712SignTypedDataOptions): IEIP712Digest;
   buildDisplayModel(typedData: IEIP712TypedData): IEIP712DisplayModel;
   signDigest(params: IEIP712SignDigestParams): IEIP712SignResult;
-  signTypedDataEIP712(params: IEIP712SignTypedDataParams): IEIP712SignResult;
+  signTypedData(params: IEIP712SignTypedDataParams): IEIP712SignResult;
   recoverSigner(params: IEIP712RecoverSignerParams): string;
   verifySignature(params: IEIP712VerifySignatureParams): boolean;
   prepareSignatureRequest(


### PR DESCRIPTION
## Summary

Renames the public `EIP712Repository` signing method consumed by the wallet from `signTypedDataEIP712` back to `signTypedData`.

This reverts the public-facing part of the naming introduced in #47, restoring the original `signTypedData` method name on the repository contract (`IEIP712Repository` + `EIP712Repository`).

## Scope

- **Renamed (public, consumed by the wallet):** `IEIP712Repository.signTypedData`, `EIP712Repository.signTypedData`, JSDoc and the corresponding unit test.
- **Kept (internal):** the signing utilities in `utils/eip712/sign.ts` (`signTypedDataEIP712`, `signTypedDataEIP712DigestWithKey`, `signTypedDataEIP712WithRawKey`), the `...Util` alias import and the `'signTypedDataEIP712'` error-source tag.

## Verification

- `tsc --noEmit` clean
- `eslint` clean
- `jest` — all eip712 suites pass (90 tests)