### PR TITLE
Release/1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-30 — EIP-712 typed-data signing
+
+### Added
+
+- **EIP-712 typed-data signing module.** New `eip712` domain (entities, repository interface, errors), `repositories/eip712` implementation, `dto/eip712` mappers, and `utils/eip712` helpers (`address`, `digest`, `displayModel`, `recover`, `sign`, `validation`). Supports parsing, validating, building a human-readable display model for, signing, and recovering EIP-712 typed data. Wired into `setupRepositories()` as `eip712Repository`. (#41, #42)
+- EIP-712 display enrichment: decode `address` values as Casper keys, human-readable date presentation, and CAIP-2 chain identification. (#51)
+- `contractPackageHash` support for CsprTrade token URLs — `getMarketDataProviderUrl()` now deep-links to `https://cspr.trade/token-details/<hash>` instead of the site root. (#43)
+
+### Changed
+
+- Renamed EIP-712 repository methods onto the `…TypedData…` convention (`EIP712Repository.signTypedData`). (#47, #52)
+- Bumped CI workflow actions: `actions/checkout` 4→7, `actions/setup-node` 4→6, `actions/upload-artifact` 4→7, `github/codeql-action` 3→4. (#28, #29, #30, #31, #48)
+- Bumped runtime and dev dependencies, including `lint-staged` 15→17. (#37, #40, #44, #49)
+
+### Fixed
+
+- Dropped a duplicated chain-name row from the EIP-712 domain rows. (#46)
+
 ## [1.3.0] - 2026-05-18
 
 ### Added
@@ -195,7 +213,8 @@ Tag exists; no GitHub release notes were published. See the
 Tagged but not published as GitHub Releases. See the
 [tag list](https://github.com/make-software/casper-wallet-core/tags) for history.
 
-[Unreleased]: https://github.com/make-software/casper-wallet-core/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/make-software/casper-wallet-core/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/make-software/casper-wallet-core/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/make-software/casper-wallet-core/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/make-software/casper-wallet-core/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/make-software/casper-wallet-core/compare/v1.1.8...v1.2.0

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Each domain module exposes a repository interface (in `src/domain/<module>/repos
 | `domain/appEvents`            | `appEventsRepository`          | Wallet-wide announcements / app events                |
 | `domain/tx-signature-request` | `txSignatureRequestRepository` | Decoding & describing transactions awaiting signature |
 | `domain/contractPackage`      | `contractPackageRepository`    | Contract package metadata lookups                     |
+| `domain/eip712`               | `eip712Repository`             | EIP-712 typed-data parsing, display, signing          |
 
 > ⚠️ Note the naming asymmetry between `domain/` and `data/repositories/` (e.g. `domain/validator` ↔ `repositories/validators`, `domain/tx-signature-request` ↔ `repositories/txSignatureRequest`). Always import from the package root to avoid drift.
 
@@ -245,6 +246,7 @@ Tests live next to the code they cover (e.g. `src/utils/common.test.ts`, `src/da
 │   │   ├── constants/
 │   │   ├── contractPackage/
 │   │   ├── deploys/
+│   │   ├── eip712/
 │   │   ├── env/
 │   │   ├── nfts/
 │   │   ├── onRamp/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CasperWalletCore",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Core business logic and data layer for the Casper Wallet browser extension and mobile app.",
   "license": "Apache-2.0",
   "author": "MAKE Software",


### PR DESCRIPTION
Release **1.4.0** — EIP-712 typed-data signing.

## Added

- **EIP-712 typed-data signing module.** New `eip712` domain (entities, repository interface, errors), `repositories/eip712` implementation, `dto/eip712` mappers, and `utils/eip712` helpers (`address`, `digest`, `displayModel`, `recover`, `sign`, `validation`). Supports parsing, validating, building a human-readable display model for, signing, and recovering EIP-712 typed data. Wired into `setupRepositories()` as `eip712Repository`. (#41, #42)
- EIP-712 display enrichment: decode `address` values as Casper keys, human-readable date presentation, and CAIP-2 chain identification. (#51)
- `contractPackageHash` support for CsprTrade token URLs — `getMarketDataProviderUrl()` now deep-links to `https://cspr.trade/token-details/<hash>` instead of the site root. (#43)

## Changed

- Renamed EIP-712 repository methods onto the `…TypedData…` convention (`EIP712Repository.signTypedData`). (#47, #52)
- Bumped CI workflow actions: `actions/checkout` 4→7, `actions/setup-node` 4→6, `actions/upload-artifact` 4→7, `github/codeql-action` 3→4. (#28, #29, #30, #31, #48)
- Bumped runtime and dev dependencies, including `lint-staged` 15→17. (#37, #40, #44, #49)

## Fixed

- Dropped a duplicated chain-name row from the EIP-712 domain rows. (#46)
