### PR TITLE
feat: expose csprNameExpiresAt from cspr-name resolution

### DIFF
--- a/src/__test-utils__/fixtures.ts
+++ b/src/__test-utils__/fixtures.ts
@@ -171,6 +171,7 @@ export const makeAccountInfo = (overrides: Partial<IAccountInfo> = {}): IAccount
   name: 'Alice',
   brandingLogo: null,
   csprName: null,
+  csprNameExpiresAt: null,
   explorerLink: null,
   ...overrides,
 });

--- a/src/data/dto/accountInfo.test.ts
+++ b/src/data/dto/accountInfo.test.ts
@@ -15,6 +15,7 @@ describe('AccountsInfoDto', () => {
       expect(dto.name).toBe('Alice');
       expect(dto.brandingLogo).toBe('https://example.com/logo.png');
       expect(dto.csprName).toBe('alice.cspr');
+      expect(dto.csprNameExpiresAt).toBeNull();
       expect(dto.explorerLink).toContain(CasperLiveUrl.mainnet);
     });
 
@@ -43,6 +44,7 @@ describe('AccountsInfoDto', () => {
       expect(dto.name).toBe('');
       expect(dto.brandingLogo).toBeNull();
       expect(dto.csprName).toBeNull();
+      expect(dto.csprNameExpiresAt).toBeNull();
     });
   });
 
@@ -61,6 +63,7 @@ describe('AccountsInfoDto', () => {
 
       expect(dto.publicKey).toBe('0202aa');
       expect(dto.csprName).toBe('bob.cspr');
+      expect(dto.csprNameExpiresAt).toBe('2099-01-01T00:00:00.000Z');
       expect(dto.brandingLogo).toBe('svg-url');
     });
   });
@@ -77,6 +80,7 @@ describe('AccountsInfoDto', () => {
       expect(dto.publicKey).toBe('0202ee');
       expect(dto.name).toBe('Caller');
       expect(dto.csprName).toBe('caller.cspr');
+      expect(dto.csprNameExpiresAt).toBeNull();
     });
   });
 
@@ -93,6 +97,8 @@ describe('AccountsInfoDto', () => {
       expect(to.publicKey).toBe('to-pk');
       expect(from.accountHash).toBe('from-hash');
       expect(to.accountHash).toBe('to-hash');
+      expect(from.csprNameExpiresAt).toBeNull();
+      expect(to.csprNameExpiresAt).toBeNull();
     });
   });
 });

--- a/src/data/dto/accountInfo.ts
+++ b/src/data/dto/accountInfo.ts
@@ -19,6 +19,7 @@ export class AccountsInfoDto implements IAccountInfo {
     this.name = info.name;
     this.brandingLogo = info.brandingLogo;
     this.csprName = info.csprName;
+    this.csprNameExpiresAt = info.csprNameExpiresAt;
     this.explorerLink = info.explorerLink;
   }
 
@@ -28,6 +29,7 @@ export class AccountsInfoDto implements IAccountInfo {
   readonly name: string;
   readonly brandingLogo: Maybe<string>;
   readonly csprName: Maybe<string>;
+  readonly csprNameExpiresAt: Maybe<string>;
   readonly explorerLink: Maybe<string>;
 
   static fromGetAccountsInfoResponse(
@@ -47,6 +49,7 @@ export class AccountsInfoDto implements IAccountInfo {
         result?.centralized_account_info?.avatar_url ??
         null,
       csprName: result?.cspr_name ?? null,
+      csprNameExpiresAt: null,
       explorerLink: getBlockExplorerAccountUrl(network, publicKey || accountHash),
     });
   }
@@ -68,6 +71,7 @@ export class AccountsInfoDto implements IAccountInfo {
         result?.centralized_account_info?.avatar_url ??
         null,
       csprName: result?.name ?? null,
+      csprNameExpiresAt: result?.expires_at ?? null,
       explorerLink: getBlockExplorerAccountUrl(network, publicKey || accountHash),
     });
   }
@@ -86,6 +90,7 @@ export class AccountsInfoDto implements IAccountInfo {
         result?.centralized_account_info?.avatar_url ??
         null,
       csprName: result?.caller_cspr_name ?? null,
+      csprNameExpiresAt: null,
       explorerLink: getBlockExplorerAccountUrl(network, publicKey || accountHash),
     });
   }
@@ -110,6 +115,7 @@ export class AccountsInfoDto implements IAccountInfo {
           result?.from_purse_centralized_account_info?.avatar_url ??
           null,
         csprName: result?.from_purse_cspr_name ?? null,
+        csprNameExpiresAt: null,
         explorerLink: getBlockExplorerAccountUrl(network, fromPublicKey || fromAccountHash),
       }),
       new AccountsInfoDto({
@@ -125,6 +131,7 @@ export class AccountsInfoDto implements IAccountInfo {
           result?.to_purse_centralized_account_info?.avatar_url ??
           null,
         csprName: result?.to_purse_cspr_name ?? null,
+        csprNameExpiresAt: null,
         explorerLink: getBlockExplorerAccountUrl(network, toPublicKey || toAccountHash),
       }),
     ];
@@ -153,6 +160,7 @@ export class AccountsInfoDto implements IAccountInfo {
           result?.from_centralized_account_info?.avatar_url ??
           null,
         csprName: result?.from_cspr_name ?? null,
+        csprNameExpiresAt: null,
         explorerLink: getBlockExplorerAccountUrl(network, fromPublicKey || fromAccountHash),
       }),
       new AccountsInfoDto({
@@ -168,6 +176,7 @@ export class AccountsInfoDto implements IAccountInfo {
           result?.to_centralized_account_info?.avatar_url ??
           null,
         csprName: result?.to_cspr_name ?? null,
+        csprNameExpiresAt: null,
         explorerLink: getBlockExplorerAccountUrl(network, toPublicKey || toAccountHash),
       }),
     ];

--- a/src/data/dto/eip712/EIP712SignatureRequestDto.test.ts
+++ b/src/data/dto/eip712/EIP712SignatureRequestDto.test.ts
@@ -28,6 +28,7 @@ const ownerAccountInfo = {
   name: 'Alice',
   brandingLogo: null,
   csprName: null,
+  csprNameExpiresAt: null,
   explorerLink: null,
 };
 

--- a/src/data/repositories/eip712/eip712.test.ts
+++ b/src/data/repositories/eip712/eip712.test.ts
@@ -93,6 +93,7 @@ describe('EIP712Repository', () => {
     name: 'Signer',
     brandingLogo: null,
     csprName: null,
+    csprNameExpiresAt: null,
     explorerLink: null,
   };
   const pkg = {

--- a/src/domain/accountInfo/entities.ts
+++ b/src/domain/accountInfo/entities.ts
@@ -7,5 +7,6 @@ export interface IAccountInfo extends IEntity {
   name: string;
   brandingLogo: Maybe<string>;
   csprName: Maybe<string>;
+  csprNameExpiresAt: Maybe<string>;
   explorerLink: Maybe<string>;
 }

--- a/src/utils/eip712/displayModel.test.ts
+++ b/src/utils/eip712/displayModel.test.ts
@@ -114,6 +114,7 @@ describe('buildTypedDataEIP712DisplayModel', () => {
       name: 'Alice',
       brandingLogo: null,
       csprName: null,
+      csprNameExpiresAt: null,
       explorerLink: null,
     };
     // PKG_HASH = '0x' + '01'.repeat(32); strip 0x -> '01'.repeat(32)
@@ -206,6 +207,7 @@ describe('buildTypedDataEIP712DisplayModel — address kinds', () => {
       name: 'Alice',
       brandingLogo: null,
       csprName: null,
+      csprNameExpiresAt: null,
       explorerLink: null,
     };
     const model = buildTypedDataEIP712DisplayModel(td, {


### PR DESCRIPTION
## What

Surfaces the CSPR.name expiration date that the `cspr-name-resolutions/{name}` API already returns but the DTO currently drops.

- Add `csprNameExpiresAt: Maybe<string>` to `IAccountInfo`.
- Map it in `AccountsInfoDto.fromCsprNameResolution` from `result.expires_at`.
- Set it to `null` in every other `AccountsInfoDto` factory (those responses carry no expiration field).
- Update DTO tests and the pre-existing `IAccountInfo` test fixtures for the new required field.

## Why

Prerequisite for [WALLET-1348](https://make-software.atlassian.net/browse/WALLET-1348) — CSPR.name expiration banners in Casper Wallet. The wallet needs the expiration date per resolved name to decide which names expire within 14 days.

## Testing

`npm test` — 474/474 passing. `code:check` (tsc), eslint, prettier all clean.

[WALLET-1348]: https://make-software.atlassian.net/browse/WALLET-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ