### PR TITLE
perf: keep casper-js-sdk off the wallet startup path (WALLET-1421)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,8 @@ permissions:
 
 jobs:
   build:
-    name: Node ${{ matrix.node }} — lint, type-check, test
+    name: Node 22 — lint, type-check, test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['20', '22']
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -28,10 +24,10 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Set up Node ${{ matrix.node }}
+      - name: Set up Node 22
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '22'
           cache: yarn
 
       - name: Install dependencies
@@ -45,16 +41,13 @@ jobs:
       # code can't be merged. Audits the whole tree (dev + transitive); low/moderate
       # are intentionally NOT gated (noise). Consciously-accepted, currently
       # unfixable advisories live in .yarnrc.yml -> npmAuditIgnoreAdvisories.
-      # Runs once (node 22) since the result is node-version independent.
       - name: Audit dependencies (fail on high/critical)
-        if: matrix.node == '22'
         run: yarn npm audit --all --severity high --recursive
 
       - name: Run unit tests
         run: yarn test --ci --coverage
 
       - name: Upload coverage artifact
-        if: matrix.node == '22'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report

--- a/README.md
+++ b/README.md
@@ -200,8 +200,22 @@ This package declares `"sideEffects": false`, so a bundler with tree shaking ena
 | `casper-wallet-core/src/utils/casperSdk/network`          | `getCasperNetworkByChainName`                            | no            |
 | `casper-wallet-core/src/utils/casperSdk/blockExplorer`    | `getBlockExplorer*Url`, `getContractNftUrl`              | no            |
 | `casper-wallet-core/src/domain`                           | entities, repository contracts, errors, constants        | no            |
+| `casper-wallet-core/src/setupData`                        | `setupDataRepositories` — the eight read repositories    | no            |
 | `casper-wallet-core/src/utils/casperSdk/cep-nft-transfer` | `makeNftTransferDeploy`, `makeNftTransferTransaction`, … | **yes**       |
 | `casper-wallet-core/src/utils/eip712/sign`                | EIP-712 signing                                          | **yes**       |
+| `casper-wallet-core/src/setupSigning`                     | `setupSigningRepositories` — txSignatureRequest, EIP-712 | **yes**       |
+
+### Repositories
+
+`setupRepositories()` still constructs all ten repositories and its return shape is unchanged, but it links the SDK, because two of them do. A surface that only renders balances, accounts, tokens, NFTs, validators or deploys should build its repositories with `setupDataRepositories()` from `src/setupData` instead, and construct the signing pair separately — `setupSigningRepositories()` takes the shared `httpDataProvider`, logger and the three repositories it depends on, so both halves still talk through one provider:
+
+```typescript
+import { setupDataRepositories } from 'casper-wallet-core/src/setupData';
+
+const { httpDataProvider, log, ...repositories } = setupDataRepositories();
+```
+
+Note that the SDK-linked modules are re-exported from the package root but **not** from the `utils`, `casperSdk` or `eip712` barrels. Most of `src/data` imports those barrels, so a re-export there made every DTO a transitive SDK importer on builds that do not tree-shake. Import them by path.
 
 `getAccountHashFromPublicKey` derives the account hash with `@noble/hashes` — `blake2b-256(algorithmName ‖ 0x00 ‖ publicKeyBytes)` — instead of `PublicKey.fromHex(...).accountHash()`. It is byte-for-byte identical to the SDK, including which malformed inputs it rejects and the error messages it throws; `src/utils/casperSdk/accountHash.test.ts` asserts that against the SDK itself.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
 - [Repositories](#repositories)
+- [Bundle size](#bundle-size)
 - [Development](#development)
 - [Testing](#testing)
 - [Project Structure](#project-structure)
@@ -186,6 +187,32 @@ Each domain module exposes a repository interface (in `src/domain/<module>/repos
 - **Financial math:** always use `Decimal` from `decimal.js`. Never use native JS numbers for balances or amounts.
 - **HTTP:** all network access flows through `IHttpDataProvider`. Repositories receive it via constructor injection — easy to mock in tests.
 - **Errors:** domain errors implement the `IDomainError` interface and are re-exported from each module.
+
+## Bundle size
+
+`casper-js-sdk` ships a single prebuilt UMD bundle (`dist/lib.web.js` — no `module` field, no `import` condition in `exports`, no `sideEffects` flag). One value import of it costs the whole ~900 KB parsed, and nothing can be shaken back out. Anything a wallet client evaluates while rendering its first screen should therefore avoid it.
+
+This package declares `"sideEffects": false`, so a bundler with tree shaking enabled drops the unused half even when you import from the package root. For builds where that cannot be relied on, the SDK-free helpers also have stable deep-import paths:
+
+| Import path                                               | Exports                                                  | Links the SDK |
+| --------------------------------------------------------- | -------------------------------------------------------- | ------------- |
+| `casper-wallet-core/src/utils/casperSdk/accountHash`      | `getAccountHashFromPublicKey`                            | no            |
+| `casper-wallet-core/src/utils/casperSdk/network`          | `getCasperNetworkByChainName`                            | no            |
+| `casper-wallet-core/src/utils/casperSdk/blockExplorer`    | `getBlockExplorer*Url`, `getContractNftUrl`              | no            |
+| `casper-wallet-core/src/domain`                           | entities, repository contracts, errors, constants        | no            |
+| `casper-wallet-core/src/utils/casperSdk/cep-nft-transfer` | `makeNftTransferDeploy`, `makeNftTransferTransaction`, … | **yes**       |
+| `casper-wallet-core/src/utils/eip712/sign`                | EIP-712 signing                                          | **yes**       |
+
+`getAccountHashFromPublicKey` derives the account hash with `@noble/hashes` — `blake2b-256(algorithmName ‖ 0x00 ‖ publicKeyBytes)` — instead of `PublicKey.fromHex(...).accountHash()`. It is byte-for-byte identical to the SDK, including which malformed inputs it rejects and the error messages it throws; `src/utils/casperSdk/accountHash.test.ts` asserts that against the SDK itself.
+
+Two guards keep this from regressing, both in `yarn test`:
+
+- `src/utils/casperSdk/accountHash.test.ts` — property-based parity against `casper-js-sdk` for both key algorithms.
+- `src/sdk-free-modules.test.ts` — walks the static import graph of each SDK-free entry point and fails if any runtime import reaches `casper-js-sdk`. `import type` is ignored, since it is erased at compile time.
+
+When adding code to the `domain` layer or to the SDK-free `utils` modules, prefer `import type` for anything used only in type position, and import from the specific module rather than a barrel.
+
+> ⚠️ `"sideEffects": false` fails silently: a module imported for what it does on evaluation, rather than for its exports, would be dropped. The package has no such module today — keep it that way.
 
 ## Development
 

--- a/index.ts
+++ b/index.ts
@@ -2,3 +2,10 @@ export * from './src/utils';
 export * from './src/setup';
 export * from './src/domain';
 export * from './src/typings';
+// The two SDK-backed util modules. They are re-exported here rather than from the `utils` /
+// `casperSdk` / `eip712` barrels, because those are reached from most of `src/data` — a
+// re-export there made every DTO a transitive `casper-js-sdk` importer. The package root already
+// links the SDK through `./src/setup`, so nothing is lost by exporting them here, and the public
+// API is exactly what it was (WALLET-1421).
+export * from './src/utils/casperSdk/cep-nft-transfer';
+export * from './src/utils/eip712/sign';

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@casper-ecosystem/casper-eip-712": "1.2.1",
     "@noble/hashes": "^1.8.0",
     "apisauce": "^3.2.2",
-    "casper-js-sdk": "5.0.12",
+    "casper-js-sdk": "5.0.13",
     "date-fns": "^4.4.0",
     "decimal.js": "^10.6.0",
     "deepmerge": "^4.3.1",
@@ -62,10 +62,13 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
-    "axios": "^1.18.1",
+    "axios": "^1.19.0",
     "form-data": "^4.0.6",
-    "bn.js": "^5.2.3",
-    "elliptic": "6.6.1"
+    "bn.js": "^5.2.5",
+    "brace-expansion@^1.1.7": "^1.1.18",
+    "brace-expansion@^5.0.5": "^5.0.9",
+    "js-yaml@^3.13.1": "^3.15.1",
+    "js-yaml@^4.3.0": "^4.3.1"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --fix"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@casper-ecosystem/casper-eip-712": "1.2.1",
     "@noble/hashes": "^1.8.0",
     "apisauce": "^3.2.2",
-    "casper-js-sdk": "5.0.13",
+    "casper-js-sdk": "5.1.0",
     "date-fns": "^4.4.0",
     "decimal.js": "^10.6.0",
     "deepmerge": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cspr"
   ],
   "main": "index.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/make-software/casper-wallet-core"

--- a/src/data/data-providers/http/logger.ts
+++ b/src/data/data-providers/http/logger.ts
@@ -1,7 +1,9 @@
 import { ApiResponse, Monitor } from 'apisauce';
 
-import { getCurrentTime } from '../../../utils';
-import { ILogger } from '../../../domain';
+// Deep imports, not the `utils` / `domain` barrels: those re-export the SDK-backed transfer
+// builders and EIP-712 signer, which would put `casper-js-sdk` behind every HTTP call.
+import { getCurrentTime } from '../../../utils/date';
+import type { ILogger } from '../../../domain/common/logger';
 
 const logRequestResult = (
   { config, status, originalError, ok, data }: ApiResponse<unknown>,

--- a/src/data/dto/accountInfo.ts
+++ b/src/data/dto/accountInfo.ts
@@ -1,5 +1,5 @@
 import { CasperNetwork, IAccountInfo } from '../../domain';
-import {
+import type {
   DeployTransferResult,
   FTActionsResult,
   ICloudAccountInfoResult,
@@ -9,7 +9,8 @@ import {
   NftCloudActionsResult,
 } from '../repositories';
 import { Maybe } from '../../typings';
-import { getAccountHashFromPublicKey, getBlockExplorerAccountUrl } from '../../utils';
+import { getAccountHashFromPublicKey } from '../../utils/casperSdk/accountHash';
+import { getBlockExplorerAccountUrl } from '../../utils/casperSdk/blockExplorer';
 
 export class AccountsInfoDto implements IAccountInfo {
   constructor(info: IAccountInfo) {

--- a/src/data/dto/appEvents.ts
+++ b/src/data/dto/appEvents.ts
@@ -1,5 +1,5 @@
 import { IAppMarketingEvent, IAppReleaseEvent } from '../../domain';
-import { IMarketingEventApiResponse, IReleaseEventApiResponse } from '../repositories';
+import type { IMarketingEventApiResponse, IReleaseEventApiResponse } from '../repositories';
 
 export class AppReleaseEventDto implements IAppReleaseEvent {
   constructor(apiEvent?: Partial<IReleaseEventApiResponse>) {

--- a/src/data/dto/common.ts
+++ b/src/data/dto/common.ts
@@ -15,7 +15,7 @@ import {
   SupportedMarketDataProviders,
 } from '../../domain';
 import { Maybe } from '../../typings';
-import { ITokenMarketData } from '../repositories';
+import type { ITokenMarketData } from '../repositories';
 
 export function getCsprFiatAmount(amount: string | number, rate?: string | number) {
   const isZeroRate = Number(rate ?? 0) === 0;

--- a/src/data/dto/contractPackage.ts
+++ b/src/data/dto/contractPackage.ts
@@ -1,5 +1,5 @@
 import { IContractPackage } from '../../domain';
-import { IContractPackageCloudResponse } from '../repositories';
+import type { IContractPackageCloudResponse } from '../repositories';
 import { Maybe } from '../../typings';
 
 export class ContractPackageDto implements IContractPackage {

--- a/src/data/dto/deploys/ActionResults.ts
+++ b/src/data/dto/deploys/ActionResults.ts
@@ -16,7 +16,7 @@ import {
   NFTEntryPointType,
 } from '../../../domain';
 import { getAccountInfoFromMap, getNftTokenUrlsMap } from '../common';
-import {
+import type {
   ExtendedCloudDeploy,
   FTActionsResult,
   ICloudTransactionFeedItem,

--- a/src/data/dto/deploys/AssociatedKeysDeployDto.ts
+++ b/src/data/dto/deploys/AssociatedKeysDeployDto.ts
@@ -1,6 +1,6 @@
 import { DeployDto } from './DeployDto';
 import { getEntryPoint } from './common';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import { IAccountInfo, IAssociatedKeysDeploy, Network } from '../../../domain';
 import { Maybe } from '../../../typings';
 

--- a/src/data/dto/deploys/AuctionDeployDto.ts
+++ b/src/data/dto/deploys/AuctionDeployDto.ts
@@ -10,7 +10,7 @@ import { getDeployAmount, getEntryPoint } from './common';
 import { deriveKeyType, getAccountInfoFromMap } from '../common';
 import { formatTokenBalance, getDecimalTokenBalance } from '../../../utils';
 import { DeployDto } from './DeployDto';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import { Maybe } from '../../../typings';
 import { getCsprFiatAmount } from '../common';
 

--- a/src/data/dto/deploys/Cep18DeployDto.ts
+++ b/src/data/dto/deploys/Cep18DeployDto.ts
@@ -13,7 +13,7 @@ import {
   isNotEmpty,
 } from '../../../utils';
 import { DeployDto } from './DeployDto';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import {
   AccountKeyType,
   CEP18EntryPointType,

--- a/src/data/dto/deploys/Cep18transferDeployDto.ts
+++ b/src/data/dto/deploys/Cep18transferDeployDto.ts
@@ -28,7 +28,7 @@ import {
 } from '../common';
 import { getCsprFiatAmount } from '../common';
 import { Maybe } from '../../../typings';
-import { IErc20TokensTransferResponse } from '../../repositories';
+import type { IErc20TokensTransferResponse } from '../../repositories';
 
 export class Cep18TransferDeployDto implements ICep18Deploy {
   constructor(

--- a/src/data/dto/deploys/CsprMarketDeployDto.ts
+++ b/src/data/dto/deploys/CsprMarketDeployDto.ts
@@ -18,7 +18,7 @@ import {
   Network,
 } from '../../../domain';
 import { DeployDto } from './DeployDto';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import { Maybe } from '../../../typings';
 import { getAccountInfoFromMap, getCsprFiatAmount, getNftTokenUrlsMap } from '../common';
 

--- a/src/data/dto/deploys/CsprTransferDeployDto.ts
+++ b/src/data/dto/deploys/CsprTransferDeployDto.ts
@@ -18,7 +18,7 @@ import {
 import { getAccountInfoFromMap } from '../common';
 import { getCsprFiatAmount } from '../common';
 import { Maybe } from '../../../typings';
-import { ICsprTransferResponse } from '../../repositories';
+import type { ICsprTransferResponse } from '../../repositories';
 
 export class CsprTransferDeployDto implements INativeCsprDeploy {
   constructor(

--- a/src/data/dto/deploys/DeployDto.ts
+++ b/src/data/dto/deploys/DeployDto.ts
@@ -18,7 +18,7 @@ import {
   getNftActionsResult,
   getTransferActionsResult,
 } from './ActionResults';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import { Maybe } from '../../../typings';
 import { getCsprFiatAmount } from '../common';
 import Decimal from 'decimal.js';

--- a/src/data/dto/deploys/NativeCsprDeployDto.ts
+++ b/src/data/dto/deploys/NativeCsprDeployDto.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../domain';
 import { derivePublicKeyFromTransfersActionResults, getDeployAmount } from './common';
 import { DeployDto } from './DeployDto';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import { Maybe } from '../../../typings';
 import { getAccountInfoFromMap, getCsprFiatAmount } from '../common';
 

--- a/src/data/dto/deploys/NftDeployDto.ts
+++ b/src/data/dto/deploys/NftDeployDto.ts
@@ -7,7 +7,7 @@ import {
   guardedDeriveSplitDataFromArguments,
 } from './common';
 import { DeployDto } from './DeployDto';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import { isKeysEqual } from '../../../utils';
 import {
   AccountKeyType,

--- a/src/data/dto/deploys/common.ts
+++ b/src/data/dto/deploys/common.ts
@@ -19,7 +19,7 @@ import {
   Network,
 } from '../../../domain';
 
-import {
+import type {
   ExtendedCloudDeploy,
   ExtendedDeployArgsResult,
   IApiDeployArgs,

--- a/src/data/dto/deploys/index.ts
+++ b/src/data/dto/deploys/index.ts
@@ -1,4 +1,4 @@
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../repositories';
 import { NativeCsprDeployDto } from './NativeCsprDeployDto';
 import { Cep18DeployDto } from './Cep18DeployDto';
 import { NftDeployDto } from './NftDeployDto';

--- a/src/data/dto/nfts.ts
+++ b/src/data/dto/nfts.ts
@@ -8,7 +8,7 @@ import {
   NftTokenIdType,
   RETINA_SCALE,
 } from '../../domain';
-import { IApiNft, ImageProxyUrlProps, NFtMetadataEntry } from '../repositories';
+import type { IApiNft, ImageProxyUrlProps, NFtMetadataEntry } from '../repositories';
 import { Maybe } from '../../typings';
 
 export class NftDto implements INft {

--- a/src/data/dto/onRamp.ts
+++ b/src/data/dto/onRamp.ts
@@ -5,7 +5,11 @@ import {
   IOnRampProvider,
   IOnRampProvidersOptions,
 } from '../../domain';
-import { IGetOnRampResponse, IOnRampProvidersResponse, IResponseCountry } from '../repositories';
+import type {
+  IGetOnRampResponse,
+  IOnRampProvidersResponse,
+  IResponseCountry,
+} from '../repositories';
 import { Maybe } from '../../typings';
 
 export class OnRampDto implements IOnRampOptions {

--- a/src/data/dto/tokens.ts
+++ b/src/data/dto/tokens.ts
@@ -10,7 +10,7 @@ import {
   SupportedFiatCurrencies,
   SupportedMarketDataProviders,
 } from '../../domain';
-import { ApiToken, IGetCsprBalanceResponse, IGetCurrencyRateResponse } from '../repositories';
+import type { ApiToken, IGetCsprBalanceResponse, IGetCurrencyRateResponse } from '../repositories';
 import { Maybe } from '../../typings';
 import {
   dexIdToMarketDataProviderMap,

--- a/src/data/dto/validators.test.ts
+++ b/src/data/dto/validators.test.ts
@@ -1,5 +1,27 @@
+import {
+  DEFAULT_MAXIMUM_DELEGATION_AMOUNT,
+  DEFAULT_MINIMUM_DELEGATION_AMOUNT,
+} from 'casper-js-sdk';
+
 import { ValidatorDto, ValidatorWithStateDto } from './validators';
 import { makeApiValidator } from '../../__test-utils__';
+
+// `validators.ts` declares these locally so it does not link the SDK for two numbers. The SDK
+// is the oracle: if it ever changes them, this fails instead of the wallet silently defaulting
+// a validator's delegation bounds to stale values.
+describe('delegation defaults stay in step with casper-js-sdk', () => {
+  it('uses the SDK minimum when the API omits one', () => {
+    expect(
+      new ValidatorDto({ ...makeApiValidator(), minimum_delegation_amount: undefined }).minAmount,
+    ).toBe(DEFAULT_MINIMUM_DELEGATION_AMOUNT.toString());
+  });
+
+  it('uses the SDK maximum when the API omits one', () => {
+    expect(
+      new ValidatorDto({ ...makeApiValidator(), maximum_delegation_amount: undefined }).maxAmount,
+    ).toBe(DEFAULT_MAXIMUM_DELEGATION_AMOUNT.toString());
+  });
+});
 
 describe('ValidatorDto', () => {
   it('builds with stake formatting and minimum delegation defaults', () => {

--- a/src/data/dto/validators.ts
+++ b/src/data/dto/validators.ts
@@ -7,13 +7,21 @@ import {
   isHighStakeValidator,
 } from '../../utils';
 import { CSPR_DECIMALS, IValidator } from '../../domain';
-import { IApiValidator, IApiValidatorWithStake } from '../repositories';
+import type { IApiValidator, IApiValidatorWithStake } from '../repositories';
 import { Maybe } from '../../typings';
-import {
-  DEFAULT_MAXIMUM_DELEGATION_AMOUNT,
-  DEFAULT_MINIMUM_DELEGATION_AMOUNT,
-} from 'casper-js-sdk';
 import Decimal from 'decimal.js';
+
+/**
+ * The SDK's `DEFAULT_MINIMUM_DELEGATION_AMOUNT` / `DEFAULT_MAXIMUM_DELEGATION_AMOUNT`, in motes,
+ * declared locally.
+ *
+ * Importing them from `casper-js-sdk` links its whole ~900 KB prebuilt UMD bundle — for two
+ * numeric constants — and `ValidatorDto` is reachable from a wallet's validator list, which is
+ * one of the surfaces WALLET-1421 is keeping SDK-free. `validators.test.ts` asserts these stay
+ * equal to the SDK's, so a change upstream fails the build here rather than silently drifting.
+ */
+const DEFAULT_MINIMUM_DELEGATION_AMOUNT = BigInt(500) * BigInt(1_000_000_000);
+const DEFAULT_MAXIMUM_DELEGATION_AMOUNT = BigInt(1_000_000_000) * BigInt(1_000_000_000);
 
 export class ValidatorDto implements IValidator {
   constructor(apiValidator?: Partial<IApiValidator>) {

--- a/src/data/repositories/accountInfo/index.ts
+++ b/src/data/repositories/accountInfo/index.ts
@@ -14,10 +14,11 @@ import {
   CasperNetwork,
 } from '../../../domain';
 import type { IHttpDataProvider } from '../../../domain';
-import { AccountsInfoDto, CsprBalanceDto } from '../../dto';
+import { AccountsInfoDto } from '../../dto/accountInfo';
+import { CsprBalanceDto } from '../../dto/tokens';
 import { ICloudResolveFromCsprNameResponse, IGetAccountsInfoResponse } from './types';
 
-import { isExpired } from '../../../utils';
+import { isExpired } from '../../../utils/date';
 import { Maybe } from '../../../typings';
 import { IGetCsprBalanceResponse } from '../tokens';
 import { ICloudTransactionFeedItem } from '../deploys';

--- a/src/data/repositories/appEvents/index.ts
+++ b/src/data/repositories/appEvents/index.ts
@@ -13,9 +13,9 @@ import {
   isAppEventsError,
 } from '../../../domain';
 import { IMarketingEventApiResponse, IReleaseEventApiResponse } from './types';
-import { AppMarketingEventDto, AppReleaseEventDto } from '../../dto';
+import { AppMarketingEventDto, AppReleaseEventDto } from '../../dto/appEvents';
 import { Maybe } from '../../../typings';
-import { isAppEventActive } from '../../../utils';
+import { isAppEventActive } from '../../../utils/date';
 import { IEnv } from '../../../domain/env';
 
 export * from './types';

--- a/src/data/repositories/contractPackage/index.ts
+++ b/src/data/repositories/contractPackage/index.ts
@@ -10,7 +10,7 @@ import {
   isContractPackageError,
 } from '../../../domain';
 import { IContractPackageCloudResponse } from './types';
-import { ContractPackageDto } from '../../dto';
+import { ContractPackageDto } from '../../dto/contractPackage';
 
 export * from './types';
 

--- a/src/data/repositories/deploys/index.ts
+++ b/src/data/repositories/deploys/index.ts
@@ -15,8 +15,8 @@ import {
   CasperNetwork,
 } from '../../../domain';
 import type { IHttpDataProvider, IAccountInfoRepository } from '../../../domain';
-import { getAccountHashFromPublicKey } from '../../../utils';
-import { CsprTransferDeployDto, processDeploy, Cep18TransferDeployDto } from '../../dto';
+import { getAccountHashFromPublicKey } from '../../../utils/casperSdk/accountHash';
+import { CsprTransferDeployDto, processDeploy, Cep18TransferDeployDto } from '../../dto/deploys';
 import {
   ExtendedCloudDeploy,
   ICloudTransactionFeedItem,

--- a/src/data/repositories/eip712/index.ts
+++ b/src/data/repositories/eip712/index.ts
@@ -26,10 +26,14 @@ import {
   computeTypedDataEIP712Digest,
   getCasperNetworkByChainName,
   recoverTypedDataEIP712SignerAddress,
-  signTypedDataEIP712 as signTypedDataEIP712Util,
-  signTypedDataEIP712DigestWithKey,
   verifyTypedDataEIP712Signature,
 } from '../../../utils';
+// By path: the `utils` barrel no longer re-exports the signer, so that the DTO layer can import
+// the barrel without linking `casper-js-sdk`. This repository links it either way.
+import {
+  signTypedDataEIP712 as signTypedDataEIP712Util,
+  signTypedDataEIP712DigestWithKey,
+} from '../../../utils/eip712/sign';
 import {
   EIP712_CHAIN_NAME_KEY,
   EIP712SignatureRequestDto,

--- a/src/data/repositories/nfts/index.ts
+++ b/src/data/repositories/nfts/index.ts
@@ -13,8 +13,8 @@ import {
   CasperNetwork,
 } from '../../../domain';
 import type { IHttpDataProvider } from '../../../domain';
-import { getAccountHashFromPublicKey } from '../../../utils';
-import { NftDto } from '../../dto';
+import { getAccountHashFromPublicKey } from '../../../utils/casperSdk/accountHash';
+import { NftDto } from '../../dto/nfts';
 import { IApiNft } from './types';
 
 export * from './types';

--- a/src/data/repositories/onRamp/index.ts
+++ b/src/data/repositories/onRamp/index.ts
@@ -10,7 +10,7 @@ import {
   OnRampError,
 } from '../../../domain';
 import type { IHttpDataProvider } from '../../../domain';
-import { OnRampDto, OnRampProvidersDto } from '../../dto';
+import { OnRampDto, OnRampProvidersDto } from '../../dto/onRamp';
 import { IGetOnRampResponse, IOnRampProvidersResponse } from './types';
 
 export * from './types';

--- a/src/data/repositories/tokens/index.ts
+++ b/src/data/repositories/tokens/index.ts
@@ -14,8 +14,8 @@ import {
   CasperNetwork,
 } from '../../../domain';
 import type { IHttpDataProvider } from '../../../domain';
-import { CsprBalanceDto, TokenDto, TokenFiatRateDto } from '../../dto';
-import { getAccountHashFromPublicKey } from '../../../utils';
+import { CsprBalanceDto, TokenDto, TokenFiatRateDto } from '../../dto/tokens';
+import { getAccountHashFromPublicKey } from '../../../utils/casperSdk/accountHash';
 import { Erc20Token, IGetCsprBalanceResponse, IGetCurrencyRateResponse } from './types';
 
 export * from './types';

--- a/src/data/repositories/validators/index.ts
+++ b/src/data/repositories/validators/index.ts
@@ -14,7 +14,7 @@ import {
   ValidatorsError,
 } from '../../../domain';
 import type { IHttpDataProvider } from '../../../domain';
-import { ValidatorDto, ValidatorWithStateDto } from '../../dto';
+import { ValidatorDto, ValidatorWithStateDto } from '../../dto/validators';
 import { IApiValidator, IApiValidatorWithStake, IAuctionMetricsResponse } from './types';
 
 export * from './types';

--- a/src/domain/accountInfo/repository.ts
+++ b/src/domain/accountInfo/repository.ts
@@ -2,7 +2,8 @@ import { IAccountInfo } from './entities';
 import { CasperNetwork, Network } from '../common';
 import { Maybe } from '../../typings';
 import { ICsprBalance } from '../tokens';
-import { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../data/repositories';
+// Type-only: `domain` must not link `data` at runtime — the data barrel reaches `casper-js-sdk`.
+import type { ExtendedCloudDeploy, ICloudTransactionFeedItem } from '../../data/repositories';
 
 export interface IGetAccountsInfoParams {
   accountHashes: string[];

--- a/src/domain/common/http/data-provider.ts
+++ b/src/domain/common/http/data-provider.ts
@@ -1,5 +1,8 @@
 import { IDomainError } from '../errors';
-import {
+// Type-only: these are all type aliases, and a value import of the `domain` barrel from here
+// would pull the whole repository graph — including `casper-js-sdk` — into every module that
+// touches the HTTP contracts.
+import type {
   AccountInfoErrorType,
   DeploysErrorType,
   NftsErrorType,

--- a/src/domain/constants/casperNetwork.ts
+++ b/src/domain/constants/casperNetwork.ts
@@ -1,7 +1,11 @@
 import { CasperNetwork, IContractInfo, Network } from '../common';
-import { ICsprBalance, IToken, NftStandard } from '../../domain';
+import { ICsprBalance, IToken } from '../tokens';
+import { NftStandard } from '../nfts';
 import { IEnv } from '../env';
-import { CasperNetworkName } from 'casper-js-sdk';
+// Type-only: importing the `CasperNetworkName` enum as a value would link the whole
+// `casper-js-sdk` UMD bundle into every consumer of these constants. The chain-name strings are
+// declared locally below instead — see `casperChainNameToCasperNetwork`.
+import type { CasperNetworkName } from 'casper-js-sdk';
 
 export const CSPR_DECIMALS = 9;
 
@@ -241,11 +245,17 @@ export const AssociatedKeysContractInfo: Record<CasperNetwork, IContractInfo> = 
   },
 };
 
+/**
+ * Chain name → {@link CasperNetwork}. Keys are the `CasperNetworkName` values spelled out
+ * literally so this module carries no runtime dependency on `casper-js-sdk`; the
+ * `Record<CasperNetworkName, …>` annotation keeps them checked against the SDK enum, so a key
+ * added to or renamed in the SDK fails the build here rather than silently going unmapped.
+ */
 export const casperChainNameToCasperNetwork: Record<CasperNetworkName, CasperNetwork> = {
-  [CasperNetworkName.Mainnet]: 'mainnet',
-  [CasperNetworkName.Testnet]: 'testnet',
-  [CasperNetworkName.DevNet]: 'devnet',
-  [CasperNetworkName.Integration]: 'integration',
+  casper: 'mainnet',
+  'casper-test': 'testnet',
+  'dev-net': 'devnet',
+  'integration-test': 'integration',
 };
 
 export const CEP_18_ACTION_ENTRY_POINTS = [

--- a/src/domain/eip712/repository.ts
+++ b/src/domain/eip712/repository.ts
@@ -1,4 +1,6 @@
-import { PrivateKey } from 'casper-js-sdk';
+// Type-only: this contract is reachable from the `domain` barrel, which sits on the wallet
+// startup path. A value import here would link the whole `casper-js-sdk` bundle.
+import type { PrivateKey } from 'casper-js-sdk';
 import {
   IEIP712Digest,
   IEIP712DisplayModel,

--- a/src/domain/onRamp/entities.ts
+++ b/src/domain/onRamp/entities.ts
@@ -1,4 +1,5 @@
-import {
+// Type-only: `domain` must not link `data` at runtime — the data barrel reaches `casper-js-sdk`.
+import type {
   IGetOnRampResponse,
   IOnRampProvidersResponse,
   IResponseCountry,

--- a/src/sdk-free-modules.test.ts
+++ b/src/sdk-free-modules.test.ts
@@ -25,6 +25,9 @@ const SDK_FREE_ENTRY_POINTS = [
   // The whole domain layer: entities, contracts and constants only. Both wallet clients
   // deep-import this barrel from render-path modules.
   'src/domain/index.ts',
+  // The data repositories a home screen renders from. `src/setup.ts` builds the signing
+  // repositories too and links the SDK by design; this is the half that must not.
+  'src/setupData.ts',
 ];
 
 interface Import {

--- a/src/sdk-free-modules.test.ts
+++ b/src/sdk-free-modules.test.ts
@@ -1,0 +1,125 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Guards the invariant WALLET-1421 buys: the helpers a wallet client calls while rendering its
+ * home screen must not reach `casper-js-sdk`.
+ *
+ * The SDK ships one prebuilt UMD bundle with no ESM build and no `sideEffects` flag, so a single
+ * value import of it links ~900 KB that no bundler can shake back out. Tree-shaking can hide a
+ * regression here (the host build may still drop it), which is precisely why this is checked
+ * statically instead of being left to a bundle measurement in another repo.
+ *
+ * `import type` / `export type` are ignored: TypeScript and Babel both erase them, so they cost
+ * nothing at runtime.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/** Modules a client can import to render a home screen without linking the SDK. */
+const SDK_FREE_ENTRY_POINTS = [
+  'src/utils/casperSdk/accountHash.ts',
+  'src/utils/casperSdk/network.ts',
+  'src/utils/casperSdk/blockExplorer.ts',
+  'src/domain/constants/casperNetwork.ts',
+  // The whole domain layer: entities, contracts and constants only. Both wallet clients
+  // deep-import this barrel from render-path modules.
+  'src/domain/index.ts',
+];
+
+interface Import {
+  specifier: string;
+  typeOnly: boolean;
+}
+
+// `import ... from 'x'`, `export ... from 'x'`, and bare `import 'x'`.
+const IMPORT_PATTERN =
+  /(?:^|[\n;])\s*(?:import|export)\s+(?:([\s\S]*?)\s+from\s*)?['"]([^'"]+)['"]/g;
+
+const parseImports = (source: string): Import[] => {
+  const imports: Import[] = [];
+
+  for (const [, clause, specifier] of source.matchAll(IMPORT_PATTERN)) {
+    // `import type { X } from` / `export type { X } from` — erased at compile time.
+    // A mixed `import { type X, Y }` keeps `Y`, so it is deliberately counted as a value import.
+    const typeOnly = /^type\s/.test(clause ?? '');
+    imports.push({ specifier, typeOnly });
+  }
+
+  return imports;
+};
+
+/** Resolves a relative specifier the way `moduleResolution: nodenext` does for this repo's source. */
+const resolveRelative = (fromFile: string, specifier: string): string | null => {
+  // nodenext-style `./foo.js` specifiers point at `./foo.ts` in source.
+  const target = path.resolve(path.dirname(fromFile), specifier.replace(/\.js$/, ''));
+
+  for (const candidate of [`${target}.ts`, path.join(target, 'index.ts')]) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+/** Every runtime module reachable from `entryPoint`, keyed by repo-relative path. */
+const collectRuntimeGraph = (entryPoint: string): Map<string, string[]> => {
+  const graph = new Map<string, string[]>();
+  const queue = [path.resolve(REPO_ROOT, entryPoint)];
+
+  while (queue.length > 0) {
+    const file = queue.shift() as string;
+    const relative = path.relative(REPO_ROOT, file);
+
+    if (graph.has(relative)) {
+      continue;
+    }
+
+    const packages: string[] = [];
+    graph.set(relative, packages);
+
+    for (const { specifier, typeOnly } of parseImports(fs.readFileSync(file, 'utf8'))) {
+      if (typeOnly) {
+        continue;
+      }
+
+      if (!specifier.startsWith('.')) {
+        packages.push(specifier);
+        continue;
+      }
+
+      const resolved = resolveRelative(file, specifier);
+
+      if (resolved === null) {
+        throw new Error(`Unresolved import "${specifier}" in ${relative}`);
+      }
+
+      queue.push(resolved);
+    }
+  }
+
+  return graph;
+};
+
+describe('SDK-free modules', () => {
+  it.each(SDK_FREE_ENTRY_POINTS)('%s does not reach casper-js-sdk at runtime', entryPoint => {
+    const graph = collectRuntimeGraph(entryPoint);
+
+    const offenders = [...graph]
+      .filter(([, packages]) => packages.includes('casper-js-sdk'))
+      .map(([file]) => file);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('resolves the whole graph (guards against the walker silently finding nothing)', () => {
+    expect(collectRuntimeGraph('src/utils/casperSdk/blockExplorer.ts').size).toBeGreaterThan(1);
+  });
+
+  it('still detects the SDK where it is legitimately used', () => {
+    const graph = collectRuntimeGraph('src/utils/casperSdk/cep-nft-transfer.ts');
+
+    expect([...graph.values()].flat()).toContain('casper-js-sdk');
+  });
+});

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,97 +1,37 @@
-import { HttpDataProvider } from './data/data-providers';
-import {
-  DeploysRepository,
-  TokensRepository,
-  NftsRepository,
-  ValidatorsRepository,
-  OnRampRepository,
-  AccountInfoRepository,
-  AppEventsRepository,
-  TxSignatureRequestRepository,
-  ContractPackageRepository,
-  EIP712Repository,
-} from './data/repositories';
-import { Logger } from './utils';
-import {
-  CasperNetwork,
-  CasperWalletApiByNetworkUrl,
-  CasperWalletApiByEnvUrl,
-  GrpcUrl,
-  ILogger,
-} from './domain';
-import { IEnv } from './domain/env';
+import { CasperWalletApiByEnvUrl, GrpcUrl } from './domain';
+import { setupDataRepositories } from './setupData';
+import { setupSigningRepositories } from './setupSigning';
+import type { ISetupDataRepositoriesParams } from './setupData';
+import type { CasperNetwork } from './domain';
 
-export interface ISetupRepositoriesParams {
-  debug?: boolean;
-  logger?: ILogger;
-  casperWalletApiByNetworkUrl?: Record<CasperNetwork, string>;
-  /** Environment-based url for Casper Wallet Api. Some API network agnostic and do not belong to any {@link CasperWalletApiByNetworkUrl}. Default env is PRODUCTION (in all places where it is used) */
-  casperWalletApiByEnvUrl?: Record<IEnv, string>;
+export interface ISetupRepositoriesParams extends ISetupDataRepositoriesParams {
   grpcUrl?: Record<CasperNetwork, string>;
-  httpAuthorizationHeader?: string;
 }
 
+/**
+ * Every repository, signing included.
+ *
+ * Importing this module links `casper-js-sdk` (~900 KB, one prebuilt UMD bundle that cannot be
+ * tree-shaken), because the signing repositories do. A client that only renders balances and
+ * account lists should call {@link setupDataRepositories} from `src/setupData` instead and pay
+ * nothing for the SDK — see WALLET-1421.
+ */
 export const setupRepositories = ({
-  logger,
-  debug,
-  casperWalletApiByNetworkUrl = CasperWalletApiByNetworkUrl,
-  casperWalletApiByEnvUrl = CasperWalletApiByEnvUrl,
   grpcUrl = GrpcUrl,
-  httpAuthorizationHeader,
+  ...dataParams
 }: ISetupRepositoriesParams = {}) => {
-  const log = logger ?? new Logger();
-  const httpDataProvider = new HttpDataProvider(debug ? log : null);
+  const { httpDataProvider, log, ...dataRepositories } = setupDataRepositories(dataParams);
 
-  if (httpAuthorizationHeader) {
-    httpDataProvider.setAuthHeader(httpAuthorizationHeader);
-  }
-
-  const accountInfoRepository = new AccountInfoRepository(
+  const signingRepositories = setupSigningRepositories({
     httpDataProvider,
-    casperWalletApiByNetworkUrl,
-  );
-  const tokensRepository = new TokensRepository(httpDataProvider, casperWalletApiByNetworkUrl);
-  const onRampRepository = new OnRampRepository(httpDataProvider);
-  const nftsRepository = new NftsRepository(httpDataProvider, casperWalletApiByNetworkUrl);
-  const validatorsRepository = new ValidatorsRepository(
-    httpDataProvider,
-    casperWalletApiByNetworkUrl,
-  );
-  const deploysRepository = new DeploysRepository(
-    httpDataProvider,
-    accountInfoRepository,
-    casperWalletApiByNetworkUrl,
-  );
-  const appEventsRepository = new AppEventsRepository(httpDataProvider, casperWalletApiByEnvUrl);
-  const contractPackageRepository = new ContractPackageRepository(
-    httpDataProvider,
-    casperWalletApiByNetworkUrl,
-  );
-  const txSignatureRequestRepository = new TxSignatureRequestRepository(
-    httpDataProvider,
-    accountInfoRepository,
-    tokensRepository,
-    contractPackageRepository,
-    casperWalletApiByEnvUrl,
+    accountInfoRepository: dataRepositories.accountInfoRepository,
+    tokensRepository: dataRepositories.tokensRepository,
+    contractPackageRepository: dataRepositories.contractPackageRepository,
+    casperWalletApiByEnvUrl: dataParams.casperWalletApiByEnvUrl ?? CasperWalletApiByEnvUrl,
     grpcUrl,
-    httpAuthorizationHeader,
-  );
-  const eip712Repository = new EIP712Repository(
-    accountInfoRepository,
-    contractPackageRepository,
+    httpAuthorizationHeader: dataParams.httpAuthorizationHeader,
     log,
-  );
+  });
 
-  return {
-    accountInfoRepository,
-    tokensRepository,
-    onRampRepository,
-    nftsRepository,
-    validatorsRepository,
-    deploysRepository,
-    appEventsRepository,
-    txSignatureRequestRepository,
-    contractPackageRepository,
-    eip712Repository,
-  };
+  return { ...dataRepositories, ...signingRepositories };
 };

--- a/src/setupData.ts
+++ b/src/setupData.ts
@@ -1,0 +1,96 @@
+import { HttpDataProvider } from './data/data-providers/http/http';
+import { AccountInfoRepository } from './data/repositories/accountInfo';
+import { AppEventsRepository } from './data/repositories/appEvents';
+import { ContractPackageRepository } from './data/repositories/contractPackage';
+import { DeploysRepository } from './data/repositories/deploys';
+import { NftsRepository } from './data/repositories/nfts';
+import { OnRampRepository } from './data/repositories/onRamp';
+import { TokensRepository } from './data/repositories/tokens';
+import { ValidatorsRepository } from './data/repositories/validators';
+import { Logger } from './utils/logger';
+import {
+  CasperWalletApiByNetworkUrl,
+  CasperWalletApiByEnvUrl,
+} from './domain/constants/casperNetwork';
+import type { CasperNetwork } from './domain/common/common';
+import type { ILogger } from './domain/common/logger';
+import type { IEnv } from './domain/env';
+
+/**
+ * The repositories a wallet client needs to render its home screen — every one of them
+ * SDK-free.
+ *
+ * Split out of {@link setupRepositories} because that factory constructs the signing
+ * repositories too, and those link `casper-js-sdk`: a single prebuilt UMD bundle with no ESM
+ * build and no `sideEffects` flag, so one value import costs ~900 KB that no bundler can shake
+ * back out. Since the factory constructs everything in one call, no amount of tree shaking on
+ * the client side could separate them — the split has to happen here (WALLET-1421).
+ *
+ * Import this module by path (`casper-wallet-core/src/setupData`), not through the package
+ * root: the root barrel re-exports `./src/setup`, which links the SDK.
+ *
+ * `src/sdk-free-modules.test.ts` fails the build if anything reachable from here starts
+ * importing the SDK again.
+ */
+export interface ISetupDataRepositoriesParams {
+  debug?: boolean;
+  logger?: ILogger;
+  casperWalletApiByNetworkUrl?: Record<CasperNetwork, string>;
+  /** Environment-based url for Casper Wallet Api. Some API network agnostic and do not belong to any {@link CasperWalletApiByNetworkUrl}. Default env is PRODUCTION (in all places where it is used) */
+  casperWalletApiByEnvUrl?: Record<IEnv, string>;
+  httpAuthorizationHeader?: string;
+}
+
+export const setupDataRepositories = ({
+  logger,
+  debug,
+  casperWalletApiByNetworkUrl = CasperWalletApiByNetworkUrl,
+  casperWalletApiByEnvUrl = CasperWalletApiByEnvUrl,
+  httpAuthorizationHeader,
+}: ISetupDataRepositoriesParams = {}) => {
+  const log = logger ?? new Logger();
+  const httpDataProvider = new HttpDataProvider(debug ? log : null);
+
+  if (httpAuthorizationHeader) {
+    httpDataProvider.setAuthHeader(httpAuthorizationHeader);
+  }
+
+  const accountInfoRepository = new AccountInfoRepository(
+    httpDataProvider,
+    casperWalletApiByNetworkUrl,
+  );
+  const tokensRepository = new TokensRepository(httpDataProvider, casperWalletApiByNetworkUrl);
+  const onRampRepository = new OnRampRepository(httpDataProvider);
+  const nftsRepository = new NftsRepository(httpDataProvider, casperWalletApiByNetworkUrl);
+  const validatorsRepository = new ValidatorsRepository(
+    httpDataProvider,
+    casperWalletApiByNetworkUrl,
+  );
+  const deploysRepository = new DeploysRepository(
+    httpDataProvider,
+    accountInfoRepository,
+    casperWalletApiByNetworkUrl,
+  );
+  const appEventsRepository = new AppEventsRepository(httpDataProvider, casperWalletApiByEnvUrl);
+  const contractPackageRepository = new ContractPackageRepository(
+    httpDataProvider,
+    casperWalletApiByNetworkUrl,
+  );
+
+  return {
+    accountInfoRepository,
+    tokensRepository,
+    onRampRepository,
+    nftsRepository,
+    validatorsRepository,
+    deploysRepository,
+    appEventsRepository,
+    contractPackageRepository,
+    /** Shared with {@link setupSigningRepositories} so both halves talk through one provider. */
+    httpDataProvider,
+    /** Shared with {@link setupSigningRepositories}; the resolved logger, never `undefined`. */
+    log,
+  };
+};
+
+export type IDataRepositories = ReturnType<typeof setupDataRepositories>;

--- a/src/setupSigning.ts
+++ b/src/setupSigning.ts
@@ -1,0 +1,54 @@
+import { EIP712Repository, TxSignatureRequestRepository } from './data/repositories';
+import { GrpcUrl } from './domain';
+import type { IDataRepositories } from './setupData';
+import type { CasperNetwork, ILogger } from './domain';
+import type { IEnv } from './domain/env';
+
+/**
+ * The repositories that build, parse and sign transactions.
+ *
+ * These link `casper-js-sdk`, so importing this module costs the whole ~900 KB UMD bundle.
+ * That is unavoidable — they exist to talk to the chain — which is exactly why they are here
+ * and not in {@link setupDataRepositories}: a surface that only renders balances and account
+ * lists must be able to leave this module unimported (WALLET-1421).
+ *
+ * Takes the data repositories it depends on rather than constructing its own, so both halves
+ * share one `HttpDataProvider` and one logger, as they did when a single factory built all ten.
+ */
+export interface ISetupSigningRepositoriesParams extends Pick<
+  IDataRepositories,
+  'httpDataProvider' | 'accountInfoRepository' | 'tokensRepository' | 'contractPackageRepository'
+> {
+  casperWalletApiByEnvUrl: Record<IEnv, string>;
+  grpcUrl?: Record<CasperNetwork, string>;
+  httpAuthorizationHeader?: string;
+  log: ILogger;
+}
+
+export const setupSigningRepositories = ({
+  httpDataProvider,
+  accountInfoRepository,
+  tokensRepository,
+  contractPackageRepository,
+  casperWalletApiByEnvUrl,
+  grpcUrl = GrpcUrl,
+  httpAuthorizationHeader,
+  log,
+}: ISetupSigningRepositoriesParams) => {
+  const txSignatureRequestRepository = new TxSignatureRequestRepository(
+    httpDataProvider,
+    accountInfoRepository,
+    tokensRepository,
+    contractPackageRepository,
+    casperWalletApiByEnvUrl,
+    grpcUrl,
+    httpAuthorizationHeader,
+  );
+  const eip712Repository = new EIP712Repository(
+    accountInfoRepository,
+    contractPackageRepository,
+    log,
+  );
+
+  return { txSignatureRequestRepository, eip712Repository };
+};

--- a/src/utils/casperSdk/accountHash.test.ts
+++ b/src/utils/casperSdk/accountHash.test.ts
@@ -1,0 +1,116 @@
+import fc from 'fast-check';
+import { PublicKey } from 'casper-js-sdk';
+
+import { getAccountHashFromPublicKey } from './accountHash';
+
+/**
+ * The whole point of `accountHash.ts` is to reproduce `casper-js-sdk` byte-for-byte without
+ * linking it. `casper-js-sdk` is therefore imported *here* (tests are never bundled) and used
+ * as the oracle: every assertion below compares against the SDK rather than against a constant
+ * we wrote down ourselves.
+ */
+const sdkAccountHash = (publicKey: string) => PublicKey.fromHex(publicKey).accountHash().toHex();
+
+const hex = (byteLength: number) =>
+  fc
+    .uint8Array({ minLength: byteLength, maxLength: byteLength })
+    .map(bytes => Array.from(bytes, b => b.toString(16).padStart(2, '0')).join(''));
+
+const ED25519_KEY = '0106956df3aba7115e28271d053205ec7f33cab259f8e2da2f38150f0ece65a2a8';
+const SECP256K1_KEY = '0202e99759649fa63a72c685b72e696b30c90f1deabb02d0d9b1de45eb371a73e5bb';
+
+describe('getAccountHashFromPublicKey', () => {
+  describe('parity with casper-js-sdk', () => {
+    it('matches the SDK for a known ED25519 key', () => {
+      expect(getAccountHashFromPublicKey(ED25519_KEY)).toBe(sdkAccountHash(ED25519_KEY));
+    });
+
+    it('matches the SDK for a known SECP256K1 key', () => {
+      expect(getAccountHashFromPublicKey(SECP256K1_KEY)).toBe(sdkAccountHash(SECP256K1_KEY));
+    });
+
+    it('matches the SDK for arbitrary ED25519 keys', () => {
+      fc.assert(
+        fc.property(hex(32), keyHex => {
+          const publicKey = `01${keyHex}`;
+          expect(getAccountHashFromPublicKey(publicKey)).toBe(sdkAccountHash(publicKey));
+        }),
+      );
+    });
+
+    it('matches the SDK for arbitrary SECP256K1 keys', () => {
+      fc.assert(
+        fc.property(hex(33), keyHex => {
+          const publicKey = `02${keyHex}`;
+          expect(getAccountHashFromPublicKey(publicKey)).toBe(sdkAccountHash(publicKey));
+        }),
+      );
+    });
+
+    it('accepts upper-case hex, like the SDK, and hashes it identically', () => {
+      const upperCased = `01${ED25519_KEY.slice(2).toUpperCase()}`;
+
+      expect(getAccountHashFromPublicKey(upperCased)).toBe(sdkAccountHash(upperCased));
+      expect(getAccountHashFromPublicKey(upperCased)).toBe(
+        getAccountHashFromPublicKey(ED25519_KEY),
+      );
+    });
+
+    it('returns lower-case hex with no "account-hash-" prefix', () => {
+      expect(getAccountHashFromPublicKey(ED25519_KEY)).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    /**
+     * `PublicKey.fromHex` validates the hex shape only — it builds the key through
+     * `PublicKey.fromBuffer`, which calls the ED25519/SECP256K1 constructors directly and never
+     * the `fromBytes` factories that do curve-point checks. A key that is not a point on the
+     * curve therefore hashes fine in the SDK, and must hash fine here too: diverging would mean
+     * this helper and the SDK disagree on an account hash, which is exactly the failure mode
+     * (funds to the wrong address) the parity requirement exists to prevent.
+     */
+    it('hashes structurally valid but non-curve-point keys exactly like the SDK', () => {
+      const notOnCurve = `02${'00'.repeat(33)}`;
+
+      expect(getAccountHashFromPublicKey(notOnCurve)).toBe(sdkAccountHash(notOnCurve));
+    });
+  });
+
+  describe('rejects what the SDK rejects', () => {
+    it.each([
+      ['empty string', ''],
+      ['single character', '0'],
+      ['non-hex characters', 'not-hex'],
+      ['prefix only', '01'],
+      ['unknown algorithm prefix', `03${'aa'.repeat(32)}`],
+      ['ED25519 key one byte short', `01${'aa'.repeat(31)}`],
+      ['ED25519 key one byte long', `01${'aa'.repeat(33)}`],
+      ['SECP256K1 key with an ED25519 length', `02${'aa'.repeat(32)}`],
+      ['non-hex body', `01${'zz'.repeat(32)}`],
+      ['0x-prefixed hex', `0x01${'aa'.repeat(32)}`],
+      ['leading whitespace', ` 01${'aa'.repeat(32)}`],
+    ])('throws on %s, with the same message as the SDK', (_label, publicKey) => {
+      let sdkMessage = '';
+      expect(() => {
+        try {
+          sdkAccountHash(publicKey);
+        } catch (error) {
+          sdkMessage = (error as Error).message;
+          throw error;
+        }
+      }).toThrow();
+
+      expect(() => getAccountHashFromPublicKey(publicKey)).toThrow(sdkMessage);
+    });
+
+    it('throws rather than hashing garbage for arbitrary non-key strings', () => {
+      fc.assert(
+        fc.property(
+          fc.string().filter(value => !/^0(1[0-9a-fA-F]{64}|2[0-9a-fA-F]{66})$/.test(value)),
+          value => {
+            expect(() => getAccountHashFromPublicKey(value)).toThrow();
+          },
+        ),
+      );
+    });
+  });
+});

--- a/src/utils/casperSdk/accountHash.ts
+++ b/src/utils/casperSdk/accountHash.ts
@@ -1,0 +1,80 @@
+import { blake2b } from '@noble/hashes/blake2';
+import { bytesToHex, concatBytes, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+
+/**
+ * SDK-free account hash derivation.
+ *
+ * This module deliberately imports nothing but `@noble/hashes` (already in the wallet bundle):
+ * `getAccountHashFromPublicKey` runs synchronously during the wallet home render, so it cannot be
+ * deferred behind a dynamic import, and a single `casper-js-sdk` import costs the whole prebuilt
+ * UMD blob. Keep it dependency-free — do not add repo-internal imports here.
+ *
+ * Parity with `PublicKey.fromHex(hex).accountHash().toHex()` is a hard requirement and is enforced
+ * by `accountHash.test.ts`, which uses the SDK itself as the oracle. An account hash that differs
+ * from the SDK's would send funds to the wrong address.
+ */
+
+// PublicKey casper nomenclature:
+// - public key = base16 hex => algo prefix + public key hex
+// - account hash - internal representation of a public key with a fixed length
+
+// base16 hex: '01deba7173738a7f55de3ad9dc27e081df41ff285f25887ec424a8a65b43d0cf77'
+// base64 "2qdt4zi/b/uagi2L9Y+db0I0Jt62CTpR/Td9HhiRAu0="
+
+// ED = 01 public keys should be 66 chars long (with the prefix)
+// SEC = 02 public keys should be 68 chars long (with the prefix)
+
+/** `blake2b-256`, the digest size the Casper account hash uses. */
+const ACCOUNT_HASH_LENGTH = 32;
+
+/**
+ * The exact shape check `PublicKey.fromHex` performs: `01` + 32 bytes (ED25519), or `02` + 33
+ * bytes (SECP256K1), upper- or lower-case.
+ *
+ * Note that the SDK does *not* verify the key is a point on the curve here — `fromHex` delegates
+ * to `PublicKey.fromBuffer`, which calls the per-algorithm constructors, not the `fromBytes`
+ * factories that would check. Adding a curve check would make this helper reject keys the SDK
+ * accepts, i.e. break parity, so the validation stops exactly where the SDK's does.
+ */
+const PUBLIC_KEY_HEX_PATTERN = /^0(1[0-9a-fA-F]{64}|2[0-9a-fA-F]{66})$/;
+
+/**
+ * Lower-cased `KeyAlgorithm` names, keyed by the algorithm prefix of the public key hex. These
+ * strings are hashed as part of the account hash preimage, so they must match the SDK's
+ * `KeyAlgorithm[cryptoAlg].toLowerCase()` exactly.
+ */
+const ALGORITHM_NAME_BY_PREFIX: Record<string, string> = {
+  '01': 'ed25519',
+  '02': 'secp256k1',
+};
+
+const SEPARATOR_BYTE = new Uint8Array([0]);
+
+/**
+ * Derives the account hash for a public key: `blake2b-256(algorithmName ‖ 0x00 ‖ publicKeyBytes)`.
+ *
+ * Byte-for-byte equivalent to `PublicKey.fromHex(publicKey).accountHash().toHex()`, without
+ * linking `casper-js-sdk`.
+ *
+ * @param publicKey - Public key as base16 hex including the algorithm prefix — `01` + 64 chars for
+ *   ED25519, `02` + 66 chars for SECP256K1.
+ * @returns The account hash as lower-case hex, unprefixed (no `account-hash-`).
+ * @throws If `publicKey` is not a well-formed prefixed public key hex string. Error messages match
+ *   the SDK's.
+ */
+export const getAccountHashFromPublicKey = (publicKey: string): string => {
+  if (publicKey.length < 2) {
+    throw new Error('Public key error: too short');
+  }
+
+  if (!PUBLIC_KEY_HEX_PATTERN.test(publicKey)) {
+    throw new Error('Invalid public key');
+  }
+
+  const algorithmName = ALGORITHM_NAME_BY_PREFIX[publicKey.slice(0, 2)];
+  const publicKeyBytes = hexToBytes(publicKey.slice(2));
+
+  const preimage = concatBytes(utf8ToBytes(algorithmName), SEPARATOR_BYTE, publicKeyBytes);
+
+  return bytesToHex(blake2b(preimage, { dkLen: ACCOUNT_HASH_LENGTH }));
+};

--- a/src/utils/casperSdk/blockExplorer.ts
+++ b/src/utils/casperSdk/blockExplorer.ts
@@ -1,0 +1,65 @@
+import { CasperLiveUrl } from '../../domain/constants/casperNetwork';
+import { Maybe } from '../../typings';
+import { getCasperNetworkByChainName } from './network';
+
+/**
+ * SDK-free cspr.live URL builders. As with `./network`, imports target specific domain modules
+ * rather than the `../../domain` barrel.
+ */
+
+export const getBlockExplorerAccountUrl = (
+  chainName: string,
+  accountKey: Maybe<string>,
+): Maybe<string> => {
+  const network = getCasperNetworkByChainName(chainName);
+
+  if (!(network && accountKey)) {
+    return null;
+  }
+
+  const path = accountKey?.includes('uref') ? 'uref' : 'account';
+
+  return `${CasperLiveUrl[network]}/${path}/${accountKey}`;
+};
+
+export const getBlockExplorerContractPackageUrl = (
+  chainName: string,
+  contractPackageHash: Maybe<string>,
+  contractHash: Maybe<string>,
+): Maybe<string> => {
+  const network = getCasperNetworkByChainName(chainName);
+
+  if (!(network && (contractPackageHash || contractHash))) {
+    return null;
+  }
+
+  if (contractPackageHash) {
+    return `${CasperLiveUrl[network]}/contract-package/${contractPackageHash}`;
+  }
+
+  return `${CasperLiveUrl[network]}/contract/${contractHash}`;
+};
+
+export const getBlockExplorerHashUrl = (chainName: string, hash: string): Maybe<string> => {
+  const network = getCasperNetworkByChainName(chainName);
+
+  if (!network) {
+    return null;
+  }
+
+  return `${CasperLiveUrl[network]}/search/${hash}`;
+};
+
+export const getContractNftUrl = (
+  chainName: string,
+  collectionHash: Maybe<string>,
+  tokenId: string,
+) => {
+  const network = getCasperNetworkByChainName(chainName);
+
+  if (!(network && collectionHash && tokenId)) {
+    return null;
+  }
+
+  return `${CasperLiveUrl[network]}/contracts/${collectionHash}/nfts/${tokenId}`;
+};

--- a/src/utils/casperSdk/index.test.ts
+++ b/src/utils/casperSdk/index.test.ts
@@ -11,18 +11,10 @@ import { CasperLiveUrl } from '../../domain';
 const VALID_PUBLIC_KEY = '0106956df3aba7115e28271d053205ec7f33cab259f8e2da2f38150f0ece65a2a8';
 
 describe('casperSdk helpers', () => {
-  describe('getAccountHashFromPublicKey', () => {
-    it('returns a deterministic hex string for a valid public key', () => {
-      const a = getAccountHashFromPublicKey(VALID_PUBLIC_KEY);
-      const b = getAccountHashFromPublicKey(VALID_PUBLIC_KEY);
-      expect(a).toBe(b);
-      expect(a).toMatch(/^[0-9a-f]+$/);
-      expect(a.length).toBeGreaterThan(0);
-    });
-
-    it('throws on an invalid public key', () => {
-      expect(() => getAccountHashFromPublicKey('not-hex')).toThrow();
-    });
+  // The barrel now only re-exports; behaviour lives with each module. `getAccountHashFromPublicKey`
+  // is covered in depth (SDK parity) by `./accountHash.test.ts`.
+  it('re-exports getAccountHashFromPublicKey from ./accountHash', () => {
+    expect(getAccountHashFromPublicKey(VALID_PUBLIC_KEY)).toMatch(/^[0-9a-f]{64}$/);
   });
 
   describe('getCasperNetworkByChainName', () => {

--- a/src/utils/casperSdk/index.ts
+++ b/src/utils/casperSdk/index.ts
@@ -15,9 +15,13 @@
  * The package declares `"sideEffects": false`, so a bundler that tree-shakes will also drop the
  * unused halves when importing through this barrel or the package root — the deep paths are the
  * guarantee for builds that do not.
+ *
+ * `./cep-nft-transfer` is deliberately NOT re-exported here: this barrel is reached from the
+ * `utils` barrel, which most of `src/data` imports, so re-exporting it made every DTO a
+ * transitive SDK importer for builds that do not shake. It is re-exported from the package root
+ * instead, so the public API is unchanged (WALLET-1421).
  */
 
 export * from './accountHash';
 export * from './network';
 export * from './blockExplorer';
-export * from './cep-nft-transfer';

--- a/src/utils/casperSdk/index.ts
+++ b/src/utils/casperSdk/index.ts
@@ -1,95 +1,23 @@
-import { PublicKey } from 'casper-js-sdk';
-import { casperChainNameToCasperNetwork, CasperLiveUrl, CasperNetwork } from '../../domain';
-import { Maybe } from '../../typings';
+/**
+ * Barrel over the Casper-protocol helpers. Only `./cep-nft-transfer` links `casper-js-sdk`; the
+ * other three modules are deliberately SDK-free.
+ *
+ * `casper-js-sdk` ships a single prebuilt UMD bundle (`dist/lib.web.js` — no `module` field, no
+ * `import` condition, no `sideEffects` flag), so one import of it costs the whole ~900 KB blob and
+ * nothing can be shaken out. Consumers on a startup path should import the module they need
+ * directly rather than this barrel:
+ *
+ * - `casper-wallet-core/src/utils/casperSdk/accountHash` — `getAccountHashFromPublicKey`
+ * - `casper-wallet-core/src/utils/casperSdk/network` — `getCasperNetworkByChainName`
+ * - `casper-wallet-core/src/utils/casperSdk/blockExplorer` — `getBlockExplorer*Url`, `getContractNftUrl`
+ * - `casper-wallet-core/src/utils/casperSdk/cep-nft-transfer` — the SDK-backed deploy builders
+ *
+ * The package declares `"sideEffects": false`, so a bundler that tree-shakes will also drop the
+ * unused halves when importing through this barrel or the package root — the deep paths are the
+ * guarantee for builds that do not.
+ */
 
-// PublicKey casper nomenclature:
-// - public key = base16 hex => algo prefix + public key hex
-// - account hash - internal representation of a public key with a fixed length
-
-// base16 hex: '01deba7173738a7f55de3ad9dc27e081df41ff285f25887ec424a8a65b43d0cf77'
-// base64 "2qdt4zi/b/uagi2L9Y+db0I0Jt62CTpR/Td9HhiRAu0="
-
-// ED = 01 public keys should be 66 chars long (with the prefix)
-// SEC = 02 public keys should be 68 chars long (with the prefix)
-
-export const getAccountHashFromPublicKey = (publicKey: string): string =>
-  PublicKey.fromHex(publicKey).accountHash().toHex();
-
-const CASPER_NETWORKS = new Set<string>(['mainnet', 'testnet', 'devnet', 'integration']);
-
-const isCasperNetwork = (value: string): value is CasperNetwork => CASPER_NETWORKS.has(value);
-
-/** Accepts CasperNetwork and CasperNetworkName chainNames, incl. CAIP-2 (e.g. "casper:casper-test"). */
-export const getCasperNetworkByChainName = (chainName: string): Maybe<CasperNetwork> => {
-  // CAIP-2 (e.g. "casper:casper-test") — use the reference segment after the last ':'.
-  const name = chainName.includes(':')
-    ? chainName.slice(chainName.lastIndexOf(':') + 1)
-    : chainName;
-
-  if (isCasperNetwork(name)) {
-    return name;
-  }
-
-  // Dynamic string lookup into a Record<CasperNetworkName, CasperNetwork>: widen the key type
-  // instead of asserting `name` is a valid enum member.
-  return (casperChainNameToCasperNetwork as Record<string, CasperNetwork>)[name] ?? null;
-};
-
-export const getBlockExplorerAccountUrl = (
-  chainName: string,
-  accountKey: Maybe<string>,
-): Maybe<string> => {
-  const network = getCasperNetworkByChainName(chainName);
-
-  if (!(network && accountKey)) {
-    return null;
-  }
-
-  const path = accountKey?.includes('uref') ? 'uref' : 'account';
-
-  return `${CasperLiveUrl[network]}/${path}/${accountKey}`;
-};
-
-export const getBlockExplorerContractPackageUrl = (
-  chainName: string,
-  contractPackageHash: Maybe<string>,
-  contractHash: Maybe<string>,
-): Maybe<string> => {
-  const network = getCasperNetworkByChainName(chainName);
-
-  if (!(network && (contractPackageHash || contractHash))) {
-    return null;
-  }
-
-  if (contractPackageHash) {
-    return `${CasperLiveUrl[network]}/contract-package/${contractPackageHash}`;
-  }
-
-  return `${CasperLiveUrl[network]}/contract/${contractHash}`;
-};
-
-export const getBlockExplorerHashUrl = (chainName: string, hash: string): Maybe<string> => {
-  const network = getCasperNetworkByChainName(chainName);
-
-  if (!network) {
-    return null;
-  }
-
-  return `${CasperLiveUrl[network]}/search/${hash}`;
-};
-
-export const getContractNftUrl = (
-  chainName: string,
-  collectionHash: Maybe<string>,
-  tokenId: string,
-) => {
-  const network = getCasperNetworkByChainName(chainName);
-
-  if (!(network && collectionHash && tokenId)) {
-    return null;
-  }
-
-  return `${CasperLiveUrl[network]}/contracts/${collectionHash}/nfts/${tokenId}`;
-};
-
+export * from './accountHash';
+export * from './network';
+export * from './blockExplorer';
 export * from './cep-nft-transfer';

--- a/src/utils/casperSdk/network.ts
+++ b/src/utils/casperSdk/network.ts
@@ -1,0 +1,29 @@
+import { casperChainNameToCasperNetwork } from '../../domain/constants/casperNetwork';
+import { CasperNetwork } from '../../domain/common/common';
+import { Maybe } from '../../typings';
+
+/**
+ * SDK-free chain-name resolution. Imports reach into the specific domain modules rather than the
+ * `../../domain` barrel so that consumers on the wallet startup path do not link anything they do
+ * not use — see the module comment in `./accountHash`.
+ */
+
+const CASPER_NETWORKS = new Set<string>(['mainnet', 'testnet', 'devnet', 'integration']);
+
+const isCasperNetwork = (value: string): value is CasperNetwork => CASPER_NETWORKS.has(value);
+
+/** Accepts CasperNetwork and CasperNetworkName chainNames, incl. CAIP-2 (e.g. "casper:casper-test"). */
+export const getCasperNetworkByChainName = (chainName: string): Maybe<CasperNetwork> => {
+  // CAIP-2 (e.g. "casper:casper-test") — use the reference segment after the last ':'.
+  const name = chainName.includes(':')
+    ? chainName.slice(chainName.lastIndexOf(':') + 1)
+    : chainName;
+
+  if (isCasperNetwork(name)) {
+    return name;
+  }
+
+  // Dynamic string lookup into a Record<CasperNetworkName, CasperNetwork>: widen the key type
+  // instead of asserting `name` is a valid enum member.
+  return (casperChainNameToCasperNetwork as Record<string, CasperNetwork>)[name] ?? null;
+};

--- a/src/utils/eip712/index.ts
+++ b/src/utils/eip712/index.ts
@@ -1,6 +1,9 @@
+// `./sign` is the only module here that links `casper-js-sdk` (it needs `PrivateKey`), and this
+// barrel is reached from the `utils` barrel that most of `src/data` imports. It is re-exported
+// from the package root instead, so the public API is unchanged — import it by path
+// (`casper-wallet-core/src/utils/eip712/sign`) from anywhere that already links the SDK.
 export * from './address';
 export * from './validation';
 export * from './digest';
 export * from './displayModel';
-export * from './sign';
 export * from './recover';

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,7 +563,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/bignumber@npm:^5.0.8, @ethersproject/bignumber@npm:^5.8.0":
+"@ethersproject/bignumber@npm:^5.8.0":
   version: 5.8.0
   resolution: "@ethersproject/bignumber@npm:5.8.0"
   dependencies:
@@ -574,7 +574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/bytes@npm:^5.0.5, @ethersproject/bytes@npm:^5.8.0":
+"@ethersproject/bytes@npm:^5.8.0":
   version: 5.8.0
   resolution: "@ethersproject/bytes@npm:5.8.0"
   dependencies:
@@ -583,7 +583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/constants@npm:^5.0.5":
+"@ethersproject/constants@npm:^5.8.0":
   version: 5.8.0
   resolution: "@ethersproject/constants@npm:5.8.0"
   dependencies:
@@ -987,7 +987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:^1.1.0, @noble/curves@npm:^1.8.0, @noble/curves@npm:~1.9.0":
+"@noble/curves@npm:^1.8.0, @noble/curves@npm:^1.9.7":
   version: 1.9.7
   resolution: "@noble/curves@npm:1.9.7"
   dependencies:
@@ -996,21 +996,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/ed25519@npm:^1.7.3":
+"@noble/ed25519@npm:^1.7.5":
   version: 1.7.5
   resolution: "@noble/ed25519@npm:1.7.5"
   checksum: 10c0/9ebcdf47e1cc986f270a82725ed4fdad1922fd63cca77f6bc0ba9575685db9cd73d45e66325fb62cc1d8a398010e953331b904961c1e9f18d170eebae783d5cb
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.7.0, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
+"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.7.0, @noble/hashes@npm:^1.8.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:^1.7.1":
+"@noble/secp256k1@npm:^1.7.2":
   version: 1.7.2
   resolution: "@noble/secp256k1@npm:1.7.2"
   checksum: 10c0/dda1eea78ee6d4d9ef968bd63d3f7ed387332fa1670af2c9c4c75a69bb6a0ca396bc95b5bab437e40f6f47548a12037094bda55453e30b4a23054922a13f3d27
@@ -1051,34 +1051,6 @@ __metadata:
   version: 0.86.0
   resolution: "@react-native/eslint-plugin@npm:0.86.0"
   checksum: 10c0/4d8bd7451d75dc572369ab2769647b5ec624bbb13e4a924a35cd526ee57507e3667b2eeedfd79568073dc2fa9db598788fc81b39e0b071397fc854ffd36a3ee5
-  languageName: node
-  linkType: hard
-
-"@scure/base@npm:~1.2.5":
-  version: 1.2.6
-  resolution: "@scure/base@npm:1.2.6"
-  checksum: 10c0/49bd5293371c4e062cb6ba689c8fe3ea3981b7bb9c000400dc4eafa29f56814cdcdd27c04311c2fec34de26bc373c593a1d6ca6d754398a488d587943b7c128a
-  languageName: node
-  linkType: hard
-
-"@scure/bip32@npm:^1.1.5":
-  version: 1.7.0
-  resolution: "@scure/bip32@npm:1.7.0"
-  dependencies:
-    "@noble/curves": "npm:~1.9.0"
-    "@noble/hashes": "npm:~1.8.0"
-    "@scure/base": "npm:~1.2.5"
-  checksum: 10c0/e3d4c1f207df16abcd79babcdb74d36f89bdafc90bf02218a5140cc5cba25821d80d42957c6705f35210cc5769714ea9501d4ae34732cdd1c26c9ff182a219f7
-  languageName: node
-  linkType: hard
-
-"@scure/bip39@npm:^1.2.0":
-  version: 1.6.0
-  resolution: "@scure/bip39@npm:1.6.0"
-  dependencies:
-    "@noble/hashes": "npm:~1.8.0"
-    "@scure/base": "npm:~1.2.5"
-  checksum: 10c0/73a54b5566a50a3f8348a5cfd74d2092efeefc485efbed83d7a7374ffd9a75defddf446e8e5ea0385e4adb49a94b8ae83c5bad3e16333af400e932f7da3aaff8
   languageName: node
   linkType: hard
 
@@ -1394,7 +1366,7 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.20.1"
     apisauce: "npm:^3.2.2"
-    casper-js-sdk: "npm:5.0.13"
+    casper-js-sdk: "npm:5.1.0"
     date-fns: "npm:^4.4.0"
     decimal.js: "npm:^10.6.0"
     deepmerge: "npm:^4.3.1"
@@ -1889,29 +1861,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"casper-js-sdk@npm:5.0.13":
-  version: 5.0.13
-  resolution: "casper-js-sdk@npm:5.0.13"
+"casper-js-sdk@npm:5.1.0":
+  version: 5.1.0
+  resolution: "casper-js-sdk@npm:5.1.0"
   dependencies:
-    "@ethersproject/bignumber": "npm:^5.0.8"
-    "@ethersproject/bytes": "npm:^5.0.5"
-    "@ethersproject/constants": "npm:^5.0.5"
-    "@noble/curves": "npm:^1.1.0"
-    "@noble/ed25519": "npm:^1.7.3"
-    "@noble/hashes": "npm:^1.2.0"
-    "@noble/secp256k1": "npm:^1.7.1"
-    "@scure/bip32": "npm:^1.1.5"
-    "@scure/bip39": "npm:^1.2.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@noble/curves": "npm:^1.9.7"
+    "@noble/ed25519": "npm:^1.7.5"
+    "@noble/hashes": "npm:^1.8.0"
+    "@noble/secp256k1": "npm:^1.7.2"
     asn1.js: "npm:^5.4.1"
     axios: "npm:^1.19.0"
-    bn.js: "npm:^5.2.1"
+    bn.js: "npm:^5.2.4"
     eventsource: "npm:^2.0.2"
-    humanize-duration: "npm:^3.24.0"
-    node-fetch: "npm:2.6.13"
-    reflect-metadata: "npm:^0.1.13"
-    ts-results: "npm:@casperlabs/ts-results@^3.3.4"
-    typedjson: "npm:^1.6.0-rc2"
-  checksum: 10c0/95cf3151aa3d200a5f29c8337f2afa92ae050a18d2bc497439ab80b4d29f66660b4cf20e2d9965037b0a391d9cf62dec7ce4e78f6370ed2778eeb3b9610b0f19
+    humanize-duration: "npm:^3.34.0"
+    ts-results: "npm:@casperlabs/ts-results@^3.3.5"
+    typedjson: "npm:^1.8.0"
+  checksum: 10c0/5cc43571a2781fce82641f1362982a173a7cfb7950b456f08fb0ed27d3931657216e0f516e9046f0005330ca21d0b0d47b6cc6591027e3ca5ffe8a0fba0dbc61
   languageName: node
   linkType: hard
 
@@ -3210,10 +3178,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"humanize-duration@npm:^3.24.0":
-  version: 3.33.2
-  resolution: "humanize-duration@npm:3.33.2"
-  checksum: 10c0/eae493c113f1c11c96e42195002e8016ab7c08bfcc3414ba5459027da4faaa2df012429bc4eae200873a65d0a86b7cc6a9656783aa45705ffe6106b5256af973
+"humanize-duration@npm:^3.34.0":
+  version: 3.34.0
+  resolution: "humanize-duration@npm:3.34.0"
+  checksum: 10c0/58f6399835a23d8ff303bf9de0a09ed8db1e42eb028f3eb04e0682f1f711d810f9a8b04668721dbcdd14d776b0d3ffb9dc136e3cb0e377e5a58bc4483ac4ea19
   languageName: node
   linkType: hard
 
@@ -4457,20 +4425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.13":
-  version: 2.6.13
-  resolution: "node-fetch@npm:2.6.13"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/39719aa365a76e5a338f20e156917ffb5c8aa8ffbe14a494f96bad785a267f3b320bf704d3481fd6df3d24d02f09cbfb8cd62fbe8f5d3ab32a812ecb7748dcac
-  languageName: node
-  linkType: hard
-
 "node-gyp@npm:latest":
   version: 12.3.0
   resolution: "node-gyp@npm:12.3.0"
@@ -4885,13 +4839,6 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
-  languageName: node
-  linkType: hard
-
-"reflect-metadata@npm:^0.1.13":
-  version: 0.1.14
-  resolution: "reflect-metadata@npm:0.1.14"
-  checksum: 10c0/3a6190c7f6cb224f26a012d11f9e329360c01c1945e2cbefea23976a8bacf9db6b794aeb5bf18adcb673c448a234fbc06fc41853c00a6c206b30f0777ecf019e
   languageName: node
   linkType: hard
 
@@ -5474,13 +5421,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
-  languageName: node
-  linkType: hard
-
 "ts-api-utils@npm:^2.5.0":
   version: 2.5.0
   resolution: "ts-api-utils@npm:2.5.0"
@@ -5530,7 +5470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-results@npm:@casperlabs/ts-results@^3.3.4":
+"ts-results@npm:@casperlabs/ts-results@^3.3.5":
   version: 3.3.5
   resolution: "@casperlabs/ts-results@npm:3.3.5"
   dependencies:
@@ -5629,7 +5569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedjson@npm:^1.6.0-rc2":
+"typedjson@npm:^1.8.0":
   version: 1.8.0
   resolution: "typedjson@npm:1.8.0"
   dependencies:
@@ -5749,23 +5689,6 @@ __metadata:
   dependencies:
     makeerror: "npm:1.0.12"
   checksum: 10c0/a17e037bccd3ca8a25a80cb850903facdfed0de4864bd8728f1782370715d679fa72e0a0f5da7c1c1379365159901e5935f35be531229da53bbfc0efdabdb48e
-  languageName: node
-  linkType: hard
-
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: "npm:~0.0.3"
-    webidl-conversions: "npm:^3.0.0"
-  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,7 +1394,7 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.20.1"
     apisauce: "npm:^3.2.2"
-    casper-js-sdk: "npm:5.0.12"
+    casper-js-sdk: "npm:5.0.13"
     date-fns: "npm:^4.4.0"
     decimal.js: "npm:^10.6.0"
     deepmerge: "npm:^4.3.1"
@@ -1650,15 +1650,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "axios@npm:1.18.1"
+"axios@npm:^1.19.0":
+  version: 1.19.0
+  resolution: "axios@npm:1.19.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
+    form-data: "npm:^4.0.6"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
+  checksum: 10c0/559fe7d51291787def61566a3db78b87510c8faf9c8a8c006d9d8b933808628ff0d8eca7756b40ae25e07da96d946c68c1ffba3da9075ed0b5d3661801d76869
   languageName: node
   linkType: hard
 
@@ -1755,29 +1755,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.2.3":
-  version: 5.2.3
-  resolution: "bn.js@npm:5.2.3"
-  checksum: 10c0/eef19cb9cf5e91e91e3e0f036b799ce6c72f79463c3934d62991c3dcdb58f6c94dc3d806495d9b0bf31cd121870ed79bb2115cea71b56c03e794fb71485031fa
+"bn.js@npm:^5.2.5":
+  version: 5.2.5
+  resolution: "bn.js@npm:5.2.5"
+  checksum: 10c0/4c47bcb261950086a9d5d311bea97197b5950703e0a80caf6e226f3bb049954a864c80b0fca7f70149c74c2e255cb4a63d0da2c425d7b15f9051a042a4e12095
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+"brace-expansion@npm:^1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+"brace-expansion@npm:^5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -1889,9 +1889,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"casper-js-sdk@npm:5.0.12":
-  version: 5.0.12
-  resolution: "casper-js-sdk@npm:5.0.12"
+"casper-js-sdk@npm:5.0.13":
+  version: 5.0.13
+  resolution: "casper-js-sdk@npm:5.0.13"
   dependencies:
     "@ethersproject/bignumber": "npm:^5.0.8"
     "@ethersproject/bytes": "npm:^5.0.5"
@@ -1903,16 +1903,15 @@ __metadata:
     "@scure/bip32": "npm:^1.1.5"
     "@scure/bip39": "npm:^1.2.0"
     asn1.js: "npm:^5.4.1"
-    axios: "npm:^1.15.0"
+    axios: "npm:^1.19.0"
     bn.js: "npm:^5.2.1"
     eventsource: "npm:^2.0.2"
-    glob: "npm:^7.1.6"
     humanize-duration: "npm:^3.24.0"
     node-fetch: "npm:2.6.13"
     reflect-metadata: "npm:^0.1.13"
     ts-results: "npm:@casperlabs/ts-results@^3.3.4"
     typedjson: "npm:^1.6.0-rc2"
-  checksum: 10c0/8fa56aa2c19247c2ce4c2f449321a10db1bbb36c3e5db7f4177caf56a05ac3bab839f3e1766ff6ab0cd6d0451a456062bca1269792d3d8b5398939160479c5ef
+  checksum: 10c0/95cf3151aa3d200a5f29c8337f2afa92ae050a18d2bc497439ab80b4d29f66660b4cf20e2d9965037b0a391d9cf62dec7ce4e78f6370ed2778eeb3b9610b0f19
   languageName: node
   linkType: hard
 
@@ -3033,7 +3032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -4113,26 +4112,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+"js-yaml@npm:^3.15.1":
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Keeps `casper-js-sdk` off the code paths a wallet client touches at startup. The SDK ships a single prebuilt UMD bundle (`dist/lib.web.js` — no `module` field, no `import` condition, no `sideEffects` flag), so one value import costs the whole ~900 KB parsed and nothing can be shaken back out.

**SDK-free account hash.** `getAccountHashFromPublicKey` runs synchronously while the home screen renders, so it cannot be deferred behind a dynamic import. `utils/casperSdk/accountHash.ts` now derives the hash with `@noble/hashes` (already in the bundle) as `blake2b-256(algorithmName || 0x00 || publicKeyBytes)`. Validation stops exactly where `PublicKey.fromHex`'s does — the hex shape only. `fromHex` routes through `fromBuffer`, which calls the ED25519 and SECP256K1 constructors rather than the `fromBytes` factories, so it never checks the key is a point on the curve. Adding a curve check would reject keys the SDK accepts, breaking the parity property that keeps funds from going to the wrong address.

**Network constants.** `domain/constants/casperNetwork.ts` imports `CasperNetworkName` as a type and spells the chain names out literally. The `Record<CasperNetworkName, CasperNetwork>` annotation still checks the keys against the SDK enum, so drift fails the build.

**Split repository factory.** `setupRepositories()` constructed all ten repositories in one call, and three of them reach the SDK — no client-side tree shaking can separate constructions that happen in the same function. It is now composed from `setupDataRepositories()` (the eight a home screen renders from, which also returns the shared `httpDataProvider` and resolved logger) and `setupSigningRepositories()`. Its return shape and parameters are unchanged, so no consumer breaks.

**Barrels and type-only imports.** `utils/casperSdk` and `utils/eip712` no longer re-export the SDK-linked modules; both are reached from the utils barrel most of `src/data` imports, which made every DTO a transitive SDK importer when the host build does not tree-shake. They are re-exported from the package root instead, so the public API is byte-for-byte what it was. Four domain imports used only in type position became `import type`, making the whole `src/domain` barrel SDK-free at runtime. `"sideEffects": false` is declared, audited beforehand for bare side-effect imports, global or prototype mutation, and top-level expression statements.

**Regression guard.** `sdk-free-modules.test.ts` walks the static import graph of each SDK-free entry point and fails if any runtime import reaches `casper-js-sdk`, ignoring `import type`. Tree shaking can otherwise hide a regression until it surfaces as bundle size in another repo.

**Dependencies.** `casper-js-sdk` 5.0.12 → 5.0.13 — a dependency and packaging hygiene release with no API surface change, which drops the unused `glob` production dependency along with the abandoned `inflight` tree. The `resolutions` block is refreshed alongside it: patch-level bumps for `brace-expansion` and `js-yaml` that clear six high advisories, `axios` and `bn.js` raised to latest, and a dead `elliptic` pin removed.

## Motivation

The SDK was reachable from every wallet surface at render time, so both wallet clients paid for the full bundle before showing anything, and no amount of downstream tree shaking could recover it. The two entry points that forced this — a synchronous account-hash call and a single-call repository factory — are addressed directly rather than worked around.

Separately, the six high advisories were already failing `yarn npm audit --all --severity high --recursive` on `master`, so the audit gate added in #61 is red on the default branch today. They are all dev-only, reached through eslint, typescript-eslint and istanbul, and none ship to library consumers.

## Related issues

Refs WALLET-1421

## Notes for reviewers

- **`data/dto/validators.ts`** declares `DEFAULT_MINIMUM_DELEGATION_AMOUNT` and `DEFAULT_MAXIMUM_DELEGATION_AMOUNT` locally rather than importing them — ~900 KB for two numbers. `validators.test.ts` pins them against the SDK's own values, so an upstream change fails the build here.
- **`accountHash.test.ts`** uses `casper-js-sdk` itself as the oracle: fixed vectors, property-based parity over arbitrary keys of both algorithms, upper-case hex, and eleven malformed inputs asserting the SDK's own error messages. The parity property is the part worth scrutinising.
- **The dependency commit is separable** from the WALLET-1421 work and can be split into its own PR if you would rather keep this one focused. The advisory fixes in it are independently cherry-pickable to `master`.
- **`brace-expansion` and `js-yaml` resolutions are range-scoped**, not bare, because both exist in two major lines in the tree. A bare `"brace-expansion": "^5.0.9"` would drag `minimatch@3`'s `^1.1.7` request onto an incompatible major.
- **`bn.js` is left as a bare resolution**, which collapses `asn1.js`'s `^4.0.0` request onto the 5.x line. This is deliberate: 4.12.5 and 5.2.5 are both clean, so the collapse is a dedupe decision rather than a security one, and `asn1.js` sits in the SDK's key-parsing path where a second bignum implementation carries more risk than the tidiness is worth.

---

- [x] Commits are signed off (DCO)
- [x] Tests added or updated where applicable
